### PR TITLE
Fix compatibility issue with flamethrower ammo setting.

### DIFF
--- a/bobwarfare/changelog.txt
+++ b/bobwarfare/changelog.txt
@@ -4,6 +4,7 @@ Date: ???
   Bugfixes:
     - Fixed Artillery Wagon Item Subgroup #110
     - Fixed graphical gap between gates and reinforced walls #130
+    - Fixed crash related to setting Vehicle flamethrower starts fires #141
   Changes:
     - Added missing prerequisites #120
     - Adjust tank recipe #129

--- a/bobwarfare/data-updates.lua
+++ b/bobwarfare/data-updates.lua
@@ -17,5 +17,33 @@ end
 table.insert(data.raw.car.tank.resistances, { type = "plasma", decrease = 15, percent = 50 })
 
 if settings.startup["bobmods-warfare-vehicleflamethrowerstartsfires"].value == true then
-  data.raw.ammo["flamethrower-ammo"].ammo_type[2].action.action_delivery.stream = "flamethrower-fire-stream"
+  data.raw.ammo["flamethrower-ammo"].ammo_type = {
+    {
+      category = "flamethrower",
+      clamp_position = true,
+      source_type = "default",
+      target_type = "position",
+      action = {
+        type = "direct",
+        action_delivery = {
+          type = "stream",
+          stream = "handheld-flamethrower-fire-stream"
+        }
+      }
+    },
+    {
+      category = "flamethrower",
+      clamp_position = true,
+      source_type = "vehicle",
+      target_type = "position",
+      consumption_modifier = 1.125,
+      action = {
+        type = "direct",
+        action_delivery = {
+          type = "stream",
+          stream = "flamethrower-fire-stream"
+        }
+      }
+    }
+  }
 end


### PR DESCRIPTION
Fixes a compatibility issue with certain other mods, such as AAI Flame Tank and Flame Tumbler, which alter flamethrower ammo to consolidate the two source_types ("default" and "vehicle") down to a single universal type, causing a crash when the "vehicle flamethrower starts fires" setting tries to modify the second source_type.