### PR TITLE
Fix K2+SE crash relating to electric furnace 2

### DIFF
--- a/bobassembly/changelog.txt
+++ b/bobassembly/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.2.1
+Date: ???
+  Bugfixes:
+    - Fixed crash relating to Electric Furnace 2 when using Krastorio 2 and Space Exploration #151
+---------------------------------------------------------------------------------------------------
 Version: 1.2.0
 Date: 22. 12. 2023
   Changes:

--- a/bobassembly/data-final-fixes.lua
+++ b/bobassembly/data-final-fixes.lua
@@ -14,13 +14,16 @@ if mods["space-exploration"] then
   bobmods.lib.tech.remove_science_pack("electronics-machine-3", "se-material-science-pack-4")
   bobmods.lib.tech.remove_science_pack("chemical-plant-3", "se-material-science-pack-1")
   bobmods.lib.tech.remove_science_pack("chemical-plant-4", "se-material-science-pack-4")
+
+  local new_subgroup = data.raw["item-subgroup"]["bob-chemical-machine"] and "bob-chemical-machine" or "bob-refinery-machine"
+
   if data.raw.item["chemical-plant-4"] then
-    data.raw.item["chemical-plant"].subgroup = "bob-chemical-machine"
+    bobmods.lib.item.set_subgroup("chemical-plant", new_subgroup)
   end
   if data.raw.item["oil-refinery-4"] then
-    data.raw.item["oil-refinery"].subgroup = "bob-chemical-machine"
-    data.raw.item["oil-refinery-2"].subgroup = "bob-chemical-machine"
-    data.raw.item["oil-refinery-3"].subgroup = "bob-chemical-machine"
-    data.raw.item["oil-refinery-4"].subgroup = "bob-chemical-machine"
+    bobmods.lib.item.set_subgroup("oil-refinery", new_subgroup)
+    bobmods.lib.item.set_subgroup("oil-refinery-2", new_subgroup)
+    bobmods.lib.item.set_subgroup("oil-refinery-3", new_subgroup)
+    bobmods.lib.item.set_subgroup("oil-refinery-4", new_subgroup)
   end
 end

--- a/bobassembly/info.json
+++ b/bobassembly/info.json
@@ -1,6 +1,6 @@
 {
   "name": "bobassembly",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "factorio_version": "1.1",
   "title": "Bob's Assembling machines mod",
   "author": "Bobingabout",

--- a/bobassembly/prototypes/se-updates.lua
+++ b/bobassembly/prototypes/se-updates.lua
@@ -863,7 +863,11 @@ if data.raw.item["electric-furnace-3"] then
     result = "electric-furnace-3",
   }
 
-  data.raw.furnace["electric-furnace-2"].energy_usage = "225kW"
+  if not mods.Krastorio2 then
+    data.raw.furnace["electric-furnace-2"].energy_usage = "225kW"
+  else
+    data.raw["assembling-machine"]["electric-furnace-2"].energy_usage = "225kW"
+  end
 
   data.raw.technology["advanced-material-processing-3"].prerequisites = {
     "advanced-material-processing-2",

--- a/bobassembly/prototypes/se-updates.lua
+++ b/bobassembly/prototypes/se-updates.lua
@@ -863,10 +863,10 @@ if data.raw.item["electric-furnace-3"] then
     result = "electric-furnace-3",
   }
 
-  if not mods.Krastorio2 then
-    data.raw.furnace["electric-furnace-2"].energy_usage = "225kW"
-  else
+  if mods["Krastorio2"] then
     data.raw["assembling-machine"]["electric-furnace-2"].energy_usage = "225kW"
+  else
+    data.raw["furnace"]["electric-furnace-2"].energy_usage = "225kW"
   end
 
   data.raw.technology["advanced-material-processing-3"].prerequisites = {


### PR DESCRIPTION
A crash occurs with Bob's Assembly + SE + Krastorio2 due to K2 replacing all furnaces with assembling machines. This edit checks for K2 and accounts for the replacement.