### PR TITLE
Update data-final-fixes with K2+SE fixes

### DIFF
--- a/boblogistics/data-final-fixes.lua
+++ b/boblogistics/data-final-fixes.lua
@@ -60,4 +60,13 @@ if mods["space-exploration"] then
       { "se-energy-science-pack-2", 1 },
     }
   end
+
+  --Krastorio2+SE fixes
+  if mods.Krastorio2 then
+    data.raw.pump.pump.fast_replaceable_group = "pipe"
+    if settings.startup["bobmods-logistics-inserteroverhaul"].value == true and data.raw.inserter["long-handed-inserter"] then
+      data.raw.inserter["long-handed-inserter"].fast_replaceable_group = "inserter"
+    end
+  end
+  
 end


### PR DESCRIPTION
Fixes two crashes related to fast replacement groups caused by the combination of Krastorio2 and Space Exploration.

This is a quick and dirty fix to just make them work together, which could be replaced later by a more permanent, comprehensive integration for Logistics+SE+K2 later.