### PR TITLE
Add support for Krastorio loaders

### DIFF
--- a/boblogistics/data-final-fixes.lua
+++ b/boblogistics/data-final-fixes.lua
@@ -62,12 +62,43 @@ if mods["space-exploration"] then
   end
 
   --Krastorio2+SE fixes
-  if mods.Krastorio2 then
+  if mods["Krastorio2"] then
     data.raw.pump.pump.fast_replaceable_group = "pipe"
-    if
-      settings.startup["bobmods-logistics-inserteroverhaul"].value == true and data.raw.inserter["long-handed-inserter"]
-    then
-      data.raw.inserter["long-handed-inserter"].fast_replaceable_group = "inserter"
+
+    if settings.startup["bobmods-logistics-inserteroverhaul"].value == true then
+      -- when both Krastorio and Space Exploration are installed,
+      -- then Space Exploration resets the `long-handed-inserter`
+      -- and `fast-inserter` recipes in a way which includes items
+      -- from both mods and making the Express Inserter ingredients
+      -- match what Bob's Logistics does with the Fast Inserter,
+      -- so just copy the ingredients over
+
+      -- Fast Inserter:
+      if data.raw.recipe["long-handed-inserter"] then
+        -- 2 x Electronic Circuit
+        -- 1 x Inserter / Inserter Parts
+        -- 1 x Steel Plate
+        if data.raw.recipe["fast-inserter"] then
+          bobmods.lib.recipe.set_ingredients("long-handed-inserter", data.raw.recipe["fast-inserter"].ingredients)
+        else
+          bobmods.lib.recipe.replace_ingredient("long-handed-inserter", "iron-stick", "electornic-circuit")
+          bobmods.lib.recipe.add_ingredient("long-handed-inserter", "steel-plate")
+        end
+      end
+
+      -- Express Inserter:
+      if data.raw.recipe["fast-inserter"] then
+        -- 2 x Adv. Circuit
+        -- 1 x Fast Inserter / Inserter Parts
+        -- 1 x Small Electric Motor
+        bobmods.lib.recipe.replace_ingredient("fast-inserter", "inserter", "long-handed-inserter")
+        bobmods.lib.recipe.replace_ingredient("fast-inserter", "electornic-circuit", "advanced-circuit")
+        bobmods.lib.recipe.replace_ingredient("fast-inserter", "steel-plate", "electric-motor")
+      end
+
+      if data.raw.inserter["long-handed-inserter"] then
+        data.raw.inserter["long-handed-inserter"].fast_replaceable_group = "inserter"
+      end
     end
   end
 end

--- a/boblogistics/data.lua
+++ b/boblogistics/data.lua
@@ -62,5 +62,5 @@ require("prototypes.chests")
 require("prototypes.repair-pack")
 
 require("prototypes.aai-loaders")
-
+require("prototypes.krastorio")
 require("prototypes.se-stage-1")

--- a/boblogistics/info.json
+++ b/boblogistics/info.json
@@ -12,6 +12,7 @@
     "? bobplates >= 1.2.0",
     "? bobinserters >= 1.2.0",
     "(?) space-exploration >= 0.6.0",
+    "(?) Krastorio2",
     "(?) aai-loaders"
   ],
   "description": "Requires Bob's functions library mod.\n\nAdds lots logistic related things in all areas.\nAdds 2 higher tiers of belt and related entities.\nBelt overhaul will change all recipes to make better use of Bob mod resources, and add a Tier 0.\nAdds a higher tier of inserters.\nInserter overhaul will add more tiers of inserter, replace long handed inserter with a menu to make other inserters long handed, and change all recipes to make better use of Bob mod resources.\nIf suitable materials are available, it will add 2 higher tiers of chest, and logistic chests\nAdds 2 higher tiers of train set (Locomotive, Cargo wagon and Fluid wagon) that will have higher speed and storage. Also adds an armored train set, and Tier 2 version of it.\nAdds tier 2 to 4 pumps, and reduces the flow to make the progression work\nAdds tier 2 to 4 of Logistic and Construction robots.\nAdds tier 2 to 4 roboports, roboport parts (intermediates), and smaller specialised entities, such as the Logistic Zone Expander and Robochest.\nAdds tier 2 to 4 of storage tank.\nAdds many new pipes made from many different materials, spanning 5 tiers.\n\nAlthough it can function as a stand alone mod, it is intended to be used with the full Bob's Mods set."

--- a/boblogistics/locale/en/boblogistics.cfg
+++ b/boblogistics/locale/en/boblogistics.cfg
@@ -264,11 +264,13 @@ turbo-transport-belt=__ITEM__prefix-purple__ __ENTITY__transport-belt__
 turbo-underground-belt=__ITEM__prefix-purple__ __ENTITY__underground-belt__
 turbo-splitter=__ITEM__prefix-purple__ __ENTITY__splitter__
 aai-turbo-loader=__ITEM__prefix-purple__ __ENTITY__loader__
+kr-turbo-loader=__ITEM__prefix-purple__ __ENTITY__loader__
 
 ultimate-transport-belt=__ITEM__prefix-green__ __ENTITY__transport-belt__
 ultimate-underground-belt=__ITEM__prefix-green__ __ENTITY__underground-belt__
 ultimate-splitter=__ITEM__prefix-green__ __ENTITY__splitter__
 aai-ultimate-loader=__ITEM__prefix-green__ __ENTITY__loader__
+kr-ultimate-loader=__ITEM__prefix-green__ __ENTITY__loader__
 
 
 storage-tank-2=__ENTITY__storage-tank__ 2
@@ -451,7 +453,7 @@ bobmods-logistics-drainlessinserters=If set to true, the idle power drain will b
 bobmods-logistics-disableroboports=If set to true, standard roboports are disabled, causing you to be reliant on the modular roboports
 bobmods-logistics-beltrequireprevious=If set to true, Transport belts and related entities require the previous tier to craft.
 bobmods-logistics-inserterrequireprevious=If set to true, Inserters require the previous tier to craft.
-bobmods-logistics-inserteroverhaul=Turning this on will overhaul inserters. It adds new tiers and a complete recipe rewrite. It also removes the long handed inserter, but you can make any inserter long-handed. 
+bobmods-logistics-inserteroverhaul=Turning this on will overhaul inserters. It adds new tiers and a complete recipe rewrite. It also removes the long handed inserter, but you can make any inserter long-handed.
 bobmods-logistics-beltoverhaul=Turning this on will overhaul transport belts, adding a new tier, ballance the speeds and a complete recipe rewrite.
 bobmods-logistics-ugdistanceoverhaul=Turning this on will change the range of all underground belts and pipes.
 bobmods-logistics-beltstarting=Sets the range on the starting tier transport belt

--- a/boblogistics/locale/ru/boblogistics.cfg
+++ b/boblogistics/locale/ru/boblogistics.cfg
@@ -264,11 +264,13 @@ turbo-transport-belt=__ITEM__prefix-purple__ __ENTITY__transport-belt__
 turbo-underground-belt=__ITEM__prefix-purple__ __ENTITY__underground-belt__
 turbo-splitter=__ITEM__prefix-purple__ __ENTITY__splitter__
 aai-turbo-loader=__ITEM__prefix-purple__ __ENTITY__loader__
+kr-turbo-loader=__ITEM__prefix-purple__ __ENTITY__loader__
 
 ultimate-transport-belt=__ITEM__prefix-green__ __ENTITY__transport-belt__
 ultimate-underground-belt=__ITEM__prefix-green__ __ENTITY__underground-belt__
 ultimate-splitter=__ITEM__prefix-green__ __ENTITY__splitter__
 aai-ultimate-loader=__ITEM__prefix-green__ __ENTITY__loader__
+kr-ultimate-loader=__ITEM__prefix-green__ __ENTITY__loader__
 
 
 storage-tank-2=__ENTITY__storage-tank__ 2

--- a/boblogistics/prototypes/krastorio.lua
+++ b/boblogistics/prototypes/krastorio.lua
@@ -1,0 +1,114 @@
+if mods["Krastorio2"] and settings.startup["kr-loaders"].value == true then
+  -- Unlike AAI Loaders, Krastorio doesn't currently have any easy to use API
+  -- for defining its loaders, so we have to make our own
+  local function create_krastorio_loader(opts)
+    local name = opts.name
+    local tier = opts.tier
+    local icon = opts.icon
+    local icon_size = opts.icon_size or 64
+    local tint = { r = opts.tint[1] / 255, g = opts.tint[2] / 255, b = opts.tint[3] / 255, a = 1 }
+    local speed = opts.speed
+    local belt_animation_set = opts.belt_animation_set
+    local upgrade = opts.upgrade or nil
+    local recipe_enabled = opts.recipe_enabled or false
+    local ingredients = opts.ingredients
+
+    local item = {
+      type = "item",
+      name = name,
+      icon = icon,
+      icon_size = icon_size,
+      subgroup = "bob-logistic-tier-" .. tier,
+      order = "d[loader]-1[" .. name .. "]",
+      place_result = name,
+      stack_size = 50,
+    }
+
+    local recipe = {
+      type = "recipe",
+      enabled = recipe_enabled,
+      name = name,
+      result = name,
+      ingredients = ingredients,
+      energy_required = 2,
+    }
+
+    local entity = util.merge({
+      data.raw["loader-1x1"]["kr-loader"],
+      {
+        name = name,
+        icon = icon,
+        icon_size = icon_size,
+        minable = { result = name },
+        placeable_by = { item = name },
+        belt_animation_set = belt_animation_set,
+        speed = speed,
+        structure = {
+          direction_in = {
+            sheets = {
+              [2] = {
+                tint = tint,
+                hr_version = {
+                  tint = tint,
+                },
+              },
+            },
+          },
+          direction_out = {
+            sheets = {
+              [2] = {
+                tint = tint,
+                hr_version = {
+                  tint = tint,
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+    entity.next_upgrade = upgrade
+
+    return { item, entity, recipe }
+  end
+
+  -- Unlike AAI Loaders, Krastorio loaders only use electricity and are unlocked
+  -- by the same research as the belt tier, so it doesn't make as much sense to add
+  -- basic loaders to Krastorio as it does to AAI (which need Lubricant or Steam to operate)
+
+  data:extend(create_krastorio_loader({
+    name = "kr-turbo-loader",
+    tier = 4,
+    -- Just reuse Krastorio's green loader icons for now
+    icon = data.raw.item["kr-superior-loader"].icon,
+    icon_size = data.raw.item["kr-superior-loader"].icon_size,
+    speed = data.raw["transport-belt"]["turbo-transport-belt"].speed,
+    belt_animation_set = data.raw["transport-belt"]["turbo-transport-belt"].belt_animation_set,
+    upgrade = "kr-ultimate-loader",
+    tint = { 180, 89, 255 },
+    ingredients = {
+      { "turbo-transport-belt", 1 },
+      { "kr-express-loader", 2 },
+      { "rare-metals", 10 },
+    },
+  }))
+
+  data:extend(create_krastorio_loader({
+    name = "kr-ultimate-loader",
+    tier = 5,
+    -- Just reuse Krastorio's purple loader icons for now
+    icon = data.raw.item["kr-advanced-loader"].icon,
+    icon_size = data.raw.item["kr-advanced-loader"].icon_size,
+    speed = data.raw["transport-belt"]["ultimate-transport-belt"].speed,
+    belt_animation_set = data.raw["transport-belt"]["ultimate-transport-belt"].belt_animation_set,
+    tint = { 180, 89, 255 },
+    ingredients = {
+      { "ultimate-transport-belt", 1 },
+      { "kr-turbo-loader", 2 },
+      { "imersium-gear-wheel", 10 },
+    },
+  }))
+
+  bobmods.lib.tech.add_recipe_unlock("logistics-4", "kr-turbo-loader")
+  bobmods.lib.tech.add_recipe_unlock("logistics-5", "kr-ultimate-loader")
+end

--- a/boblogistics/prototypes/se-updates.lua
+++ b/boblogistics/prototypes/se-updates.lua
@@ -1163,3 +1163,19 @@ data.raw.technology["inserter-capacity-bonus-8"].unit.ingredients = {
   { "se-material-science-pack-4", 1 },
   { "se-deep-space-science-pack-1", 1 },
 }
+
+if mods["Krastorio2"] and settings.startup["kr-loaders"].value == true then
+  bobmods.lib.recipe.set_ingredients("kr-turbo-loader", {
+    { "electric-engine-unit", 2 },
+    { "se-heavy-bearing", 4 },
+    { "kr-express-loader", 2 },
+    { "turbo-transport-belt", 1 },
+  })
+  bobmods.lib.recipe.set_ingredients("kr-ultimate-loader", {
+    { "se-holmium-solenoid", 4 },
+    { "se-aeroframe-scaffold", 2 },
+    { "se-heavy-composite", 2 },
+    { "kr-turbo-loader", 2 },
+    { "ultimate-transport-belt", 1 },
+  })
+end


### PR DESCRIPTION
This adds basic compatibility for **Krastorio’s** loaders and also fixes the **Fast** and **Express** inserter recipes when **K2+SE** is present.

I chose not to add **Basic Loaders**, as **Krastorio** loaders are unlocked from the same research as the belt and only need electricity to operate, so it doesn’t make as much sense to add those as it does with **AAI Loaders**, which use fluids to operate.

## Related issues
- https://github.com/modded-factorio/bobsmods/pull/154
- https://github.com/modded-factorio/bobsmods/pull/164
- https://github.com/modded-factorio/bobsmods/issues/153
- https://github.com/raiguard/Krastorio2/issues/404