### PR TITLE
Make characters not appear in Made In lists

### DIFF
--- a/bobclasses/changelog.txt
+++ b/bobclasses/changelog.txt
@@ -2,6 +2,7 @@
 Version: 1.2.1
 Date: ???
   Changes:
+    - Prevented Characters from showing in "Made in" tooltips #169
     - Removed Space Exploration compatibility changes. These have been moved to a separate compatibility mod #170
 ---------------------------------------------------------------------------------------------------
 Version: 1.2.0

--- a/bobclasses/data.lua
+++ b/bobclasses/data.lua
@@ -8,8 +8,6 @@ if not bobmods.avatars then
   bobmods.avatars = {}
 end
 
-table.insert(data.raw.character.character.flags, "not-in-made-in")
-
 require("prototypes.category")
 require("prototypes.style")
 require("prototypes.character")

--- a/bobclasses/data.lua
+++ b/bobclasses/data.lua
@@ -8,6 +8,8 @@ if not bobmods.avatars then
   bobmods.avatars = {}
 end
 
+table.insert(data.raw.character.character.flags, "not-in-made-in")
+
 require("prototypes.category")
 require("prototypes.style")
 require("prototypes.character")

--- a/bobclasses/prototypes/character.lua
+++ b/bobclasses/prototypes/character.lua
@@ -1,5 +1,6 @@
 bobmods.classes.characters = {}
 
+table.insert(data.raw.character.character.flags, "not-in-made-in")
 data.raw.character.character.fast_replaceable_group = "character"
 
 data.raw.character.character.icon = nil


### PR DESCRIPTION
This one line change adds the "not-in-made-in" flag to the basic character type. The addition is then carried forward into all other character types as their prototypes are created. Related to #169.