### PR TITLE
Quick centrifuge Bobplates+SE fix

### DIFF
--- a/bobplates/prototypes/entity/nuclear.lua
+++ b/bobplates/prototypes/entity/nuclear.lua
@@ -1,102 +1,106 @@
-data.raw["assembling-machine"]["centrifuge"].animation = nil
-data.raw["assembling-machine"]["centrifuge"].working_visualisations = {
-  {
+if not mods["space-exploration"] then
+  
+  data.raw["assembling-machine"]["centrifuge"].animation = nil
+  data.raw["assembling-machine"]["centrifuge"].working_visualisations = {
+    {
+      -- Centrifuge C, Top.
+      apply_recipe_tint = "tertiary",
+      animation = {
+        filename = "__bobplates__/graphics/entity/centrifuge/centrifuge-C-light.png",
+        priority = "high",
+        blend_mode = "additive", -- centrifuge
+        line_length = 8,
+        width = 96,
+        height = 104,
+        frame_count = 64,
+        shift = util.by_pixel(0, -27),
+        hr_version = {
+          filename = "__bobplates__/graphics/entity/centrifuge/hr-centrifuge-C-light.png",
+          priority = "high",
+          scale = 0.5,
+          blend_mode = "additive", -- centrifuge
+          line_length = 8,
+          width = 190,
+          height = 207,
+          frame_count = 64,
+          shift = util.by_pixel(0, -27.25),
+        },
+      },
+    },
+    -- Centrifuge B, Bottom right.
+    {
+      apply_recipe_tint = "secondary",
+      animation = {
+        filename = "__bobplates__/graphics/entity/centrifuge/centrifuge-B-light.png",
+        priority = "high",
+        blend_mode = "additive", -- centrifuge
+        line_length = 8,
+        width = 65,
+        height = 103,
+        frame_count = 64,
+        shift = util.by_pixel(16.5, 0.5),
+        hr_version = {
+          filename = "__bobplates__/graphics/entity/centrifuge/hr-centrifuge-B-light.png",
+          priority = "high",
+          scale = 0.5,
+          blend_mode = "additive", -- centrifuge
+          line_length = 8,
+          width = 131,
+          height = 206,
+          frame_count = 64,
+          shift = util.by_pixel(16.75, 0.5),
+        },
+      },
+    },
+    -- Centrifuge A, Bottom left.
+    {
+      apply_recipe_tint = "primary",
+      animation = {
+        filename = "__bobplates__/graphics/entity/centrifuge/centrifuge-A-light.png",
+        priority = "high",
+        blend_mode = "additive", -- centrifuge
+        line_length = 8,
+        width = 55,
+        height = 98,
+        frame_count = 64,
+        shift = util.by_pixel(-23.5, -2),
+        hr_version = {
+          filename = "__bobplates__/graphics/entity/centrifuge/hr-centrifuge-A-light.png",
+          priority = "high",
+          scale = 0.5,
+          blend_mode = "additive", -- centrifuge
+          line_length = 8,
+          width = 108,
+          height = 197,
+          frame_count = 64,
+          shift = util.by_pixel(-23.5, -1.75),
+        },
+      },
+    },
+  
     -- Centrifuge C, Top.
-    apply_recipe_tint = "tertiary",
-    animation = {
-      filename = "__bobplates__/graphics/entity/centrifuge/centrifuge-C-light.png",
-      priority = "high",
-      blend_mode = "additive", -- centrifuge
-      line_length = 8,
-      width = 96,
-      height = 104,
-      frame_count = 64,
-      shift = util.by_pixel(0, -27),
-      hr_version = {
-        filename = "__bobplates__/graphics/entity/centrifuge/hr-centrifuge-C-light.png",
-        priority = "high",
-        scale = 0.5,
-        blend_mode = "additive", -- centrifuge
-        line_length = 8,
-        width = 190,
-        height = 207,
-        frame_count = 64,
-        shift = util.by_pixel(0, -27.25),
-      },
+    {
+      effect = "uranium-glow",
+      apply_recipe_tint = "tertiary",
+      fadeout = true,
+      light = { intensity = 0.066, size = 8.9, shift = { 0, -1.2 } },
     },
-  },
-  -- Centrifuge B, Bottom right.
-  {
-    apply_recipe_tint = "secondary",
-    animation = {
-      filename = "__bobplates__/graphics/entity/centrifuge/centrifuge-B-light.png",
-      priority = "high",
-      blend_mode = "additive", -- centrifuge
-      line_length = 8,
-      width = 65,
-      height = 103,
-      frame_count = 64,
-      shift = util.by_pixel(16.5, 0.5),
-      hr_version = {
-        filename = "__bobplates__/graphics/entity/centrifuge/hr-centrifuge-B-light.png",
-        priority = "high",
-        scale = 0.5,
-        blend_mode = "additive", -- centrifuge
-        line_length = 8,
-        width = 131,
-        height = 206,
-        frame_count = 64,
-        shift = util.by_pixel(16.75, 0.5),
-      },
+  
+    -- Centrifuge B, Bottom right.
+    {
+      effect = "uranium-glow",
+      apply_recipe_tint = "secondary",
+      fadeout = true,
+      light = { intensity = 0.066, size = 8.9, shift = { 1, 0.5 } },
     },
-  },
-  -- Centrifuge A, Bottom left.
-  {
-    apply_recipe_tint = "primary",
-    animation = {
-      filename = "__bobplates__/graphics/entity/centrifuge/centrifuge-A-light.png",
-      priority = "high",
-      blend_mode = "additive", -- centrifuge
-      line_length = 8,
-      width = 55,
-      height = 98,
-      frame_count = 64,
-      shift = util.by_pixel(-23.5, -2),
-      hr_version = {
-        filename = "__bobplates__/graphics/entity/centrifuge/hr-centrifuge-A-light.png",
-        priority = "high",
-        scale = 0.5,
-        blend_mode = "additive", -- centrifuge
-        line_length = 8,
-        width = 108,
-        height = 197,
-        frame_count = 64,
-        shift = util.by_pixel(-23.5, -1.75),
-      },
+  
+    -- Centrifuge A, Bottom left.
+    {
+      effect = "uranium-glow",
+      apply_recipe_tint = "primary",
+      fadeout = true,
+      light = { intensity = 0.066, size = 8.9, shift = { -1, 0.5 } },
     },
-  },
+  }
 
-  -- Centrifuge C, Top.
-  {
-    effect = "uranium-glow",
-    apply_recipe_tint = "tertiary",
-    fadeout = true,
-    light = { intensity = 0.066, size = 8.9, shift = { 0, -1.2 } },
-  },
-
-  -- Centrifuge B, Bottom right.
-  {
-    effect = "uranium-glow",
-    apply_recipe_tint = "secondary",
-    fadeout = true,
-    light = { intensity = 0.066, size = 8.9, shift = { 1, 0.5 } },
-  },
-
-  -- Centrifuge A, Bottom left.
-  {
-    effect = "uranium-glow",
-    apply_recipe_tint = "primary",
-    fadeout = true,
-    light = { intensity = 0.066, size = 8.9, shift = { -1, 0.5 } },
-  },
-}
+end


### PR DESCRIPTION
This is a quick fix to stop bobplates from giving the centrifuge its three-color visualisation if SE is active. This is to prevent a compile error where SE tries to give the centrifuge a single-color visualisation in a way that conflicts.

Of course, this is all very much a just-in-case sort of thing, for if the B+SE mod ever gets expanded to include bobplates. There are other conflicts, but they can be fixed after the fact. This one has to be taken care of at this stage. The three-color visualisation can also be re-applied later in the B+SE mod.