### PR TITLE
Updating Bob's Modules and preparing some ground work for quality modules

### DIFF
--- a/bobmodules/data-updates.lua
+++ b/bobmodules/data-updates.lua
@@ -17,9 +17,9 @@ bobmods.lib.tech.remove_prerequisite("effect-transmission", "production-science-
 bobmods.lib.tech.add_prerequisite("effect-transmission", "modules")
 bobmods.lib.tech.add_prerequisite("effect-transmission", "chemical-science-pack")
 
-bobmods.lib.tech.remove_prerequisite("speed-module-2", "advanced-electronics-2")
-bobmods.lib.tech.remove_prerequisite("productivity-module-2", "advanced-electronics-2")
-bobmods.lib.tech.remove_prerequisite("efficiency-module-2", "advanced-electronics-2")
+bobmods.lib.tech.remove_prerequisite("speed-module-2", "processing-unit")
+bobmods.lib.tech.remove_prerequisite("productivity-module-2", "processing-unit")
+bobmods.lib.tech.remove_prerequisite("efficiency-module-2", "processing-unit")
 bobmods.lib.tech.remove_prerequisite("speed-module-3", "production-science-pack")
 bobmods.lib.tech.remove_prerequisite("productivity-module-3", "production-science-pack")
 bobmods.lib.tech.remove_prerequisite("efficiency-module-3", "production-science-pack")

--- a/bobmodules/data.lua
+++ b/bobmodules/data.lua
@@ -13,6 +13,7 @@ bobmods.modules.PollutionCreatePerLevel = settings.startup["bobmods-modules-perl
 bobmods.modules.SpeedPenaltyPerLevel = settings.startup["bobmods-modules-perlevel-penalty-speed"].value
 bobmods.modules.PollutionPenaltyPerLevel = settings.startup["bobmods-modules-perlevel-penalty-pollution"].value
 bobmods.modules.ConsumptionPenaltyPerLevel = settings.startup["bobmods-modules-perlevel-penalty-consumption"].value
+bobmods.modules.QualityPerLevel = settings.startup["bobmods-modules-perlevel-bonus-quality"].value
 
 bobmods.modules.SpeedBonus = settings.startup["bobmods-modules-start-bonus-speed"].value
 bobmods.modules.PollutionBonus = settings.startup["bobmods-modules-start-bonus-pollution"].value
@@ -22,6 +23,7 @@ bobmods.modules.PollutionCreateBonus = settings.startup["bobmods-modules-start-b
 bobmods.modules.SpeedPenalty = settings.startup["bobmods-modules-start-penalty-speed"].value
 bobmods.modules.PollutionPenalty = settings.startup["bobmods-modules-start-penalty-pollution"].value
 bobmods.modules.ConsumptionPenalty = settings.startup["bobmods-modules-start-penalty-consumption"].value
+bobmods.modules.QualityBonus = settings.startup["bobmods-modules-start-bonus-quality"].value
 
 require("prototypes.category")
 require("prototypes.beacon")
@@ -37,13 +39,8 @@ require("prototypes.recipe.electronics")
 require("prototypes.technology.module")
 require("prototypes.technology.module-merged")
 
-if settings.startup["bobmods-modules-enableproductivitylimitation"].value == true then
-  for i, module in pairs(data.raw.module) do
-    if module.effect.productivity then
-      module.limitation = productivity_module_limitation()
-      if not module.limitation_message_key then
-        module.limitation_message_key = "production-module-usable-only-on-intermediates"
-      end
-    end
+if settings.startup["bobmods-modules-enableproductivitylimitation"].value == false then
+  for recipe_name, recipe in pairs(data.raw.recipe) do
+	recipe.allow_productivity = true
   end
 end

--- a/bobmodules/locale/en/bobmodules.cfg
+++ b/bobmodules/locale/en/bobmodules.cfg
@@ -144,6 +144,7 @@ bobmods-modules-perlevel-penalty-speed=Module speed penalty per tier
 bobmods-modules-perlevel-penalty-pollution=Module pollution penalty per tier
 bobmods-modules-perlevel-penalty-consumption=Module consumption penalty per tier
 bobmods-modules-perlevel-bonus-pollutioncreate=Module pollution create bonus per tier
+bobmods-modules-perlevel-bonus-quality=Module quality bonus per tier
 
 bobmods-modules-start-bonus-speed=Module speed bonus start
 bobmods-modules-start-bonus-pollution=Module pollution bonus start
@@ -153,6 +154,7 @@ bobmods-modules-start-penalty-speed=Module speed penalty start
 bobmods-modules-start-penalty-pollution=Module pollution penalty start
 bobmods-modules-start-penalty-consumption=Module consumption penalty start
 bobmods-modules-start-bonus-pollutioncreate=Module pollution create bonus start
+bobmods-modules-start-bonus-quality=Module quality bonus start
 
 
 [mod-setting-description]

--- a/bobmodules/locale/ru/bobmodules.cfg
+++ b/bobmodules/locale/ru/bobmodules.cfg
@@ -148,6 +148,7 @@ bobmods-modules-perlevel-penalty-speed=Штраф скорости на уров
 bobmods-modules-perlevel-penalty-pollution=Штраф загрязнения на уровень
 bobmods-modules-perlevel-penalty-consumption=Штраф энергопотребления на уровень
 bobmods-modules-perlevel-bonus-pollutioncreate=Увеличение загрязнения на уровень
+bobmods-modules-perlevel-bonus-quality=Бонус качества на уровень
 
 bobmods-modules-start-bonus-speed=Начальный бонус скорости
 bobmods-modules-start-bonus-pollution=Начальный бонус загрязнения
@@ -157,6 +158,7 @@ bobmods-modules-start-penalty-speed=Начальный штраф скорост
 bobmods-modules-start-penalty-pollution=Начальный штраф загрязнения
 bobmods-modules-start-penalty-consumption=Начальный штраф энергопотребления
 bobmods-modules-start-bonus-pollutioncreate=Начальное загрязнение на уровень
+bobmods-modules-start-bonus-quality=Начальный качества скорости
 
 
 [mod-setting-description]

--- a/bobmodules/prototypes/beacon.lua
+++ b/bobmodules/prototypes/beacon.lua
@@ -96,7 +96,7 @@ data:extend({
     },
     prerequisites = {
       "effect-transmission",
-      "advanced-electronics-2",
+      "processing-unit",
       "production-science-pack",
     },
     unit = {

--- a/bobmodules/prototypes/item/module-merged.lua
+++ b/bobmodules/prototypes/item/module-merged.lua
@@ -662,7 +662,7 @@ if settings.startup["bobmods-modules-enablegodmodules"].value == true then
         productivity = 10 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
         pollution = -10 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
         consumption = -10 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
-        speed = 10 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001
+        speed = 10 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001,
       },
       limitation_message_key = "production-module-usable-only-on-intermediates",
       beacon_tint = {
@@ -673,4 +673,40 @@ if settings.startup["bobmods-modules-enablegodmodules"].value == true then
       requires_beacon_alt_mode = false,
     },
   })
+  if game.active_mods["quality"] then
+	data.raw["module"]["god-module-1"].effect = {
+        productivity = 2 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
+        pollution = -2 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+        consumption = -2 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
+        speed = 2 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001,
+        quality = 2 * bobmods.modules.QualityPerLevel + bobmods.modules.SpeedBonus + 0.001
+      }
+	data.raw["module"]["god-module-2"].effect = {
+        productivity = 4 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
+        pollution = -4 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+        consumption = -4 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
+        speed = 4 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001,
+        quality = 4 * bobmods.modules.QualityPerLevel + bobmods.modules.SpeedBonus + 0.001
+      }
+	data.raw["module"]["god-module-3"].effect = {
+        productivity = 6 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
+        pollution = -6 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+        consumption = -6 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
+        speed = 6 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001,
+        quality = 6 * bobmods.modules.QualityPerLevel + bobmods.modules.SpeedBonus + 0.001
+      }
+	data.raw["module"]["god-module-4"].effect = {
+        productivity = 8 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
+        pollution = -8 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+        consumption = -8 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
+        speed = 8 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001,
+        quality = 8à * bobmods.modules.QualityPerLevel + bobmods.modules.SpeedBonus + 0.001
+      }
+	data.raw["module"]["god-module-5"].effect = {
+        productivity = 10 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
+        pollution = -10 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+        consumption = -10 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
+        speed = 10 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001,
+        quality = 10 * bobmods.modules.QualityPerLevel + bobmods.modules.SpeedBonus + 0.001
+      }
 end

--- a/bobmodules/prototypes/item/module-merged.lua
+++ b/bobmodules/prototypes/item/module-merged.lua
@@ -673,40 +673,36 @@ if settings.startup["bobmods-modules-enablegodmodules"].value == true then
       requires_beacon_alt_mode = false,
     },
   })
-  if game.active_mods["quality"] then
+ end
+  if data.raw.technology["quality-module"] then
 	data.raw["module"]["god-module-1"].effect = {
         productivity = 2 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
         pollution = -2 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
         consumption = -2 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
         speed = 2 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001,
-        quality = 2 * bobmods.modules.QualityPerLevel + bobmods.modules.SpeedBonus + 0.001
-      }
+        quality = 2 * bobmods.modules.QualityPerLevel + bobmods.modules.SpeedBonus + 0.001 }
 	data.raw["module"]["god-module-2"].effect = {
         productivity = 4 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
         pollution = -4 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
         consumption = -4 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
         speed = 4 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001,
-        quality = 4 * bobmods.modules.QualityPerLevel + bobmods.modules.SpeedBonus + 0.001
-      }
+        quality = 4 * bobmods.modules.QualityPerLevel + bobmods.modules.SpeedBonus + 0.001 }
 	data.raw["module"]["god-module-3"].effect = {
         productivity = 6 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
         pollution = -6 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
         consumption = -6 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
         speed = 6 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001,
-        quality = 6 * bobmods.modules.QualityPerLevel + bobmods.modules.SpeedBonus + 0.001
-      }
+        quality = 6 * bobmods.modules.QualityPerLevel + bobmods.modules.SpeedBonus + 0.001 }
 	data.raw["module"]["god-module-4"].effect = {
         productivity = 8 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
         pollution = -8 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
         consumption = -8 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
         speed = 8 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001,
-        quality = 8à * bobmods.modules.QualityPerLevel + bobmods.modules.SpeedBonus + 0.001
-      }
+        quality = 8 * bobmods.modules.QualityPerLevel + bobmods.modules.SpeedBonus + 0.001 }
 	data.raw["module"]["god-module-5"].effect = {
         productivity = 10 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
         pollution = -10 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
         consumption = -10 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
         speed = 10 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001,
-        quality = 10 * bobmods.modules.QualityPerLevel + bobmods.modules.SpeedBonus + 0.001
-      }
+        quality = 10 * bobmods.modules.QualityPerLevel + bobmods.modules.SpeedBonus + 0.001 }
 end

--- a/bobmodules/prototypes/item/module-merged.lua
+++ b/bobmodules/prototypes/item/module-merged.lua
@@ -14,7 +14,7 @@ if settings.startup["bobmods-modules-enablerawspeedmodules"].value == true then
       order = "m-rs-1",
       stack_size = 100,
       default_request_amount = 10,
-      effect = { speed = { bonus = bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 } },
+      effect = { speed = bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
       beacon_tint = {
         primary = { r = 0, g = 0.8, b = 0.8 },
         secondary = { r = 0.37, g = 1, b = 1 },
@@ -34,7 +34,7 @@ if settings.startup["bobmods-modules-enablerawspeedmodules"].value == true then
       order = "m-rs-2",
       stack_size = 100,
       default_request_amount = 10,
-      effect = { speed = { bonus = 2 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 } },
+      effect = { speed = 2 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
       beacon_tint = {
         primary = { r = 0, g = 0.8, b = 0.8 },
         secondary = { r = 0.37, g = 1, b = 1 },
@@ -54,7 +54,7 @@ if settings.startup["bobmods-modules-enablerawspeedmodules"].value == true then
       order = "m-rs-3",
       stack_size = 100,
       default_request_amount = 10,
-      effect = { speed = { bonus = 3 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 } },
+      effect = { speed = 3 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
       beacon_tint = {
         primary = { r = 0, g = 0.8, b = 0.8 },
         secondary = { r = 0.37, g = 1, b = 1 },
@@ -74,7 +74,7 @@ if settings.startup["bobmods-modules-enablerawspeedmodules"].value == true then
       order = "m-rs-4",
       stack_size = 100,
       default_request_amount = 10,
-      effect = { speed = { bonus = 4 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 } },
+      effect = { speed = 4 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
       beacon_tint = {
         primary = { r = 0, g = 0.8, b = 0.8 },
         secondary = { r = 0.37, g = 1, b = 1 },
@@ -94,7 +94,7 @@ if settings.startup["bobmods-modules-enablerawspeedmodules"].value == true then
       order = "m-rs-5",
       stack_size = 100,
       default_request_amount = 10,
-      effect = { speed = { bonus = 5 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 } },
+      effect = { speed = 5 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
       beacon_tint = {
         primary = { r = 0, g = 0.8, b = 0.8 },
         secondary = { r = 0.37, g = 1, b = 1 },
@@ -114,7 +114,7 @@ if settings.startup["bobmods-modules-enablerawspeedmodules"].value == true then
       order = "m-rs-6",
       stack_size = 100,
       default_request_amount = 10,
-      effect = { speed = { bonus = 6 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 } },
+      effect = { speed = 6 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
       beacon_tint = {
         primary = { r = 0, g = 0.8, b = 0.8 },
         secondary = { r = 0.37, g = 1, b = 1 },
@@ -134,7 +134,7 @@ if settings.startup["bobmods-modules-enablerawspeedmodules"].value == true then
       order = "m-rs-7",
       stack_size = 100,
       default_request_amount = 10,
-      effect = { speed = { bonus = 7 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 } },
+      effect = { speed = 7 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
       beacon_tint = {
         primary = { r = 0, g = 0.8, b = 0.8 },
         secondary = { r = 0.37, g = 1, b = 1 },
@@ -154,7 +154,7 @@ if settings.startup["bobmods-modules-enablerawspeedmodules"].value == true then
       order = "m-rs-8",
       stack_size = 100,
       default_request_amount = 10,
-      effect = { speed = { bonus = 8 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 } },
+      effect = { speed = 8 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
       beacon_tint = {
         primary = { r = 0, g = 0.8, b = 0.8 },
         secondary = { r = 0.37, g = 1, b = 1 },
@@ -179,8 +179,8 @@ if settings.startup["bobmods-modules-enablegreenmodules"].value == true then
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        pollution = { bonus = -1 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 },
-        consumption = { bonus = -1 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 },
+        pollution = -1 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+        consumption = -1 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001
       },
       beacon_tint = {
         primary = { r = 0.8, g = 0.8, b = 0 },
@@ -202,8 +202,8 @@ if settings.startup["bobmods-modules-enablegreenmodules"].value == true then
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        pollution = { bonus = -2 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 },
-        consumption = { bonus = -2 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 },
+        pollution = -2 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+        consumption = -2 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001
       },
       beacon_tint = {
         primary = { r = 0.8, g = 0.8, b = 0 },
@@ -225,8 +225,8 @@ if settings.startup["bobmods-modules-enablegreenmodules"].value == true then
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        pollution = { bonus = -3 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 },
-        consumption = { bonus = -3 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 },
+        pollution = -3 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+        consumption = -3 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001
       },
       beacon_tint = {
         primary = { r = 0.8, g = 0.8, b = 0 },
@@ -248,8 +248,8 @@ if settings.startup["bobmods-modules-enablegreenmodules"].value == true then
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        pollution = { bonus = -4 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 },
-        consumption = { bonus = -4 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 },
+        pollution = -4 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+        consumption = -4 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001
       },
       beacon_tint = {
         primary = { r = 0.8, g = 0.8, b = 0 },
@@ -271,8 +271,8 @@ if settings.startup["bobmods-modules-enablegreenmodules"].value == true then
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        pollution = { bonus = -5 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 },
-        consumption = { bonus = -5 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 },
+        pollution = -5 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+        consumption = -5 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001
       },
       beacon_tint = {
         primary = { r = 0.8, g = 0.8, b = 0 },
@@ -294,8 +294,8 @@ if settings.startup["bobmods-modules-enablegreenmodules"].value == true then
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        pollution = { bonus = -6 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 },
-        consumption = { bonus = -6 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 },
+        pollution = -6 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+        consumption = -6 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001
       },
       beacon_tint = {
         primary = { r = 0.8, g = 0.8, b = 0 },
@@ -317,8 +317,8 @@ if settings.startup["bobmods-modules-enablegreenmodules"].value == true then
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        pollution = { bonus = -7 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 },
-        consumption = { bonus = -7 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 },
+        pollution = -7 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+        consumption = -7 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001
       },
       beacon_tint = {
         primary = { r = 0.8, g = 0.8, b = 0 },
@@ -340,8 +340,8 @@ if settings.startup["bobmods-modules-enablegreenmodules"].value == true then
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        pollution = { bonus = -8 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 },
-        consumption = { bonus = -8 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 },
+        pollution = -8 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+        consumption = -8 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001
       },
       beacon_tint = {
         primary = { r = 0.8, g = 0.8, b = 0 },
@@ -367,7 +367,7 @@ if settings.startup["bobmods-modules-enablerawproductivitymodules"].value == tru
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        productivity = { bonus = bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
+        productivity = bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001
       },
       limitation_message_key = "production-module-usable-only-on-intermediates",
       beacon_tint = {
@@ -390,7 +390,7 @@ if settings.startup["bobmods-modules-enablerawproductivitymodules"].value == tru
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        productivity = { bonus = 2 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
+        productivity = 2 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001
       },
       limitation_message_key = "production-module-usable-only-on-intermediates",
       beacon_tint = {
@@ -413,7 +413,7 @@ if settings.startup["bobmods-modules-enablerawproductivitymodules"].value == tru
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        productivity = { bonus = 3 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
+        productivity = 3 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001
       },
       limitation_message_key = "production-module-usable-only-on-intermediates",
       beacon_tint = {
@@ -436,7 +436,7 @@ if settings.startup["bobmods-modules-enablerawproductivitymodules"].value == tru
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        productivity = { bonus = 4 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
+        productivity = 4 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001
       },
       limitation_message_key = "production-module-usable-only-on-intermediates",
       beacon_tint = {
@@ -459,7 +459,7 @@ if settings.startup["bobmods-modules-enablerawproductivitymodules"].value == tru
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        productivity = { bonus = 5 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
+        productivity = 5 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001
       },
       limitation_message_key = "production-module-usable-only-on-intermediates",
       beacon_tint = {
@@ -482,7 +482,7 @@ if settings.startup["bobmods-modules-enablerawproductivitymodules"].value == tru
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        productivity = { bonus = 6 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
+        productivity = 6 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001
       },
       limitation_message_key = "production-module-usable-only-on-intermediates",
       beacon_tint = {
@@ -505,7 +505,7 @@ if settings.startup["bobmods-modules-enablerawproductivitymodules"].value == tru
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        productivity = { bonus = 7 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
+        productivity = 7 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001
       },
       limitation_message_key = "production-module-usable-only-on-intermediates",
       beacon_tint = {
@@ -528,7 +528,7 @@ if settings.startup["bobmods-modules-enablerawproductivitymodules"].value == tru
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        productivity = { bonus = 8 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
+        productivity = 8 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001
       },
       limitation_message_key = "production-module-usable-only-on-intermediates",
       beacon_tint = {
@@ -555,10 +555,10 @@ if settings.startup["bobmods-modules-enablegodmodules"].value == true then
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        productivity = { bonus = 2 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
-        pollution = { bonus = -2 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 },
-        consumption = { bonus = -2 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 },
-        speed = { bonus = 2 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
+        productivity = 2 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
+        pollution = -2 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+        consumption = -2 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
+        speed = 2 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001
       },
       limitation_message_key = "production-module-usable-only-on-intermediates",
       beacon_tint = {
@@ -581,10 +581,10 @@ if settings.startup["bobmods-modules-enablegodmodules"].value == true then
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        productivity = { bonus = 4 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
-        pollution = { bonus = -4 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 },
-        consumption = { bonus = -4 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 },
-        speed = { bonus = 4 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
+        productivity = 4 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
+        pollution = -4 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+        consumption = -4 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
+        speed = 4 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001
       },
       limitation_message_key = "production-module-usable-only-on-intermediates",
       beacon_tint = {
@@ -607,10 +607,10 @@ if settings.startup["bobmods-modules-enablegodmodules"].value == true then
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        productivity = { bonus = 6 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
-        pollution = { bonus = -6 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 },
-        consumption = { bonus = -6 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 },
-        speed = { bonus = 6 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
+        productivity = 6 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
+        pollution = -6 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+        consumption = -6 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
+        speed = 6 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001
       },
       limitation_message_key = "production-module-usable-only-on-intermediates",
       beacon_tint = {
@@ -633,10 +633,10 @@ if settings.startup["bobmods-modules-enablegodmodules"].value == true then
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        productivity = { bonus = 8 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
-        pollution = { bonus = -8 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 },
-        consumption = { bonus = -8 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 },
-        speed = { bonus = 8 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
+        productivity = 8 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
+        pollution = -8 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+        consumption = -8 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
+        speed = 8 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001
       },
       limitation_message_key = "production-module-usable-only-on-intermediates",
       beacon_tint = {
@@ -659,10 +659,10 @@ if settings.startup["bobmods-modules-enablegodmodules"].value == true then
       stack_size = 100,
       default_request_amount = 10,
       effect = {
-        productivity = { bonus = 10 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
-        pollution = { bonus = -10 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 },
-        consumption = { bonus = -10 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 },
-        speed = { bonus = 10 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
+        productivity = 10 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
+        pollution = -10 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+        consumption = -10 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
+        speed = 10 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001
       },
       limitation_message_key = "production-module-usable-only-on-intermediates",
       beacon_tint = {

--- a/bobmodules/prototypes/item/module.lua
+++ b/bobmodules/prototypes/item/module.lua
@@ -10,8 +10,8 @@ data.raw["module"]["speed-module"].default_request_amount = 10
 data.raw["module"]["speed-module"].beacon_tint =
   { primary = { r = 0, g = 0.34, b = 1, a = 1 }, secondary = { r = 0.388, g = 0.976, b = 1.000, a = 1.000 } }
 data.raw["module"]["speed-module"].effect = {
-  speed = { bonus = bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
-  consumption = { bonus = bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001 },
+  speed = bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001,
+  consumption = bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
 }
 
 data.raw["module"]["speed-module-2"].stack_size = 100
@@ -23,8 +23,8 @@ data.raw["module"]["speed-module-2"].default_request_amount = 10
 data.raw["module"]["speed-module-2"].beacon_tint =
   { primary = { r = 0, g = 0.34, b = 1, a = 1 }, secondary = { r = 0.388, g = 0.976, b = 1.000, a = 1.000 } }
 data.raw["module"]["speed-module-2"].effect = {
-  speed = { bonus = 2 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
-  consumption = { bonus = 2 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001 },
+  speed = 2 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001,
+  consumption = 2 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001
 }
 
 data.raw["module"]["speed-module-3"].stack_size = 100
@@ -36,8 +36,8 @@ data.raw["module"]["speed-module-3"].default_request_amount = 10
 data.raw["module"]["speed-module-3"].beacon_tint =
   { primary = { r = 0, g = 0.34, b = 1, a = 1 }, secondary = { r = 0.388, g = 0.976, b = 1.000, a = 1.000 } }
 data.raw["module"]["speed-module-3"].effect = {
-  speed = { bonus = 3 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
-  consumption = { bonus = 3 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001 },
+  speed = 3 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 ,
+  consumption = 3 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001
 }
 
 data:extend({
@@ -53,10 +53,8 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      speed = { bonus = 4 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
-      consumption = {
-        bonus = 4 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
-      },
+      speed = 4 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001,
+      consumption = 4 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001
     },
     beacon_tint = {
       primary = { r = 0, g = 0.34, b = 1, a = 1 },
@@ -78,10 +76,8 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      speed = { bonus = 5 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
-      consumption = {
-        bonus = 5 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
-      },
+      speed = 5 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001,
+      consumption = 5 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001
     },
     beacon_tint = {
       primary = { r = 0, g = 0.34, b = 1, a = 1 },
@@ -103,10 +99,8 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      speed = { bonus = 6 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
-      consumption = {
-        bonus = 6 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
-      },
+      speed = 6 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001,
+      consumption = 6 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001
     },
     beacon_tint = {
       primary = { r = 0, g = 0.34, b = 1, a = 1 },
@@ -128,10 +122,8 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      speed = { bonus = 7 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
-      consumption = {
-        bonus = 7 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
-      },
+      speed = 7 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001,
+      consumption = 7 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001
     },
     beacon_tint = {
       primary = { r = 0, g = 0.34, b = 1, a = 1 },
@@ -153,10 +145,8 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      speed = { bonus = 8 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001 },
-      consumption = {
-        bonus = 8 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
-      },
+      speed = 8 * bobmods.modules.SpeedPerLevel + bobmods.modules.SpeedBonus + 0.001,
+      consumption = 8 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001
     },
     beacon_tint = {
       primary = { r = 0, g = 0.34, b = 1, a = 1 },
@@ -179,7 +169,7 @@ data.raw["module"]["efficiency-module"].default_request_amount = 10
 data.raw["module"]["efficiency-module"].beacon_tint =
   { primary = { r = 0.3, g = 0.6, b = 0.1 }, secondary = { r = 0.370, g = 1.000, b = 0.370, a = 1.000 } }
 data.raw["module"]["efficiency-module"].effect =
-  { consumption = { bonus = -1 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 } }
+  { consumption = -1 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 }
 
 data.raw["module"]["efficiency-module-2"].stack_size = 100
 data.raw["module"]["efficiency-module-2"].icon = "__bobmodules__/graphics/icons/yellow-module-2.png"
@@ -190,7 +180,7 @@ data.raw["module"]["efficiency-module-2"].default_request_amount = 10
 data.raw["module"]["efficiency-module-2"].beacon_tint =
   { primary = { r = 0.3, g = 0.6, b = 0.1 }, secondary = { r = 0.370, g = 1.000, b = 0.370, a = 1.000 } }
 data.raw["module"]["efficiency-module-2"].effect =
-  { consumption = { bonus = -2 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 } }
+  { consumption = -2 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 }
 
 data.raw["module"]["efficiency-module-3"].stack_size = 100
 data.raw["module"]["efficiency-module-3"].icon = "__bobmodules__/graphics/icons/yellow-module-3.png"
@@ -201,7 +191,7 @@ data.raw["module"]["efficiency-module-3"].default_request_amount = 10
 data.raw["module"]["efficiency-module-3"].beacon_tint =
   { primary = { r = 0.3, g = 0.6, b = 0.1 }, secondary = { r = 0.370, g = 1.000, b = 0.370, a = 1.000 } }
 data.raw["module"]["efficiency-module-3"].effect =
-  { consumption = { bonus = -3 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 } }
+  { consumption = -3 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 }
 
 data:extend({
   {
@@ -216,7 +206,7 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      consumption = { bonus = -4 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 },
+      consumption = -4 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
     },
     beacon_tint = {
       primary = { r = 0.3, g = 0.6, b = 0.1 },
@@ -238,7 +228,7 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      consumption = { bonus = -5 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 },
+      consumption = -5 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
     },
     beacon_tint = {
       primary = { r = 0.3, g = 0.6, b = 0.1 },
@@ -260,7 +250,7 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      consumption = { bonus = -6 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 },
+      consumption = -6 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
     },
     beacon_tint = {
       primary = { r = 0.3, g = 0.6, b = 0.1 },
@@ -282,7 +272,7 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      consumption = { bonus = -7 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 },
+      consumption = -7 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
     },
     beacon_tint = {
       primary = { r = 0.3, g = 0.6, b = 0.1 },
@@ -304,7 +294,7 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      consumption = { bonus = -8 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001 },
+      consumption = -8 * bobmods.modules.ConsumptionPerLevel - bobmods.modules.ConsumptionBonus - 0.001,
     },
     beacon_tint = {
       primary = { r = 0.3, g = 0.6, b = 0.1 },
@@ -331,9 +321,9 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      productivity = { bonus = bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
-      consumption = { bonus = bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001 },
-      pollution = { bonus = bobmods.modules.PollutionPenaltyPerLevel + bobmods.modules.PollutionPenalty + 0.001 },
+      productivity = bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 ,
+      consumption = bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001 ,
+      pollution = bobmods.modules.PollutionPenaltyPerLevel + bobmods.modules.PollutionPenalty + 0.001
     },
     limitation_message_key = "production-module-usable-only-on-intermediates",
     beacon_tint = {
@@ -356,11 +346,9 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      productivity = { bonus = 2 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
-      consumption = {
-        bonus = 2 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
-      },
-      pollution = { bonus = 2 * bobmods.modules.PollutionPenaltyPerLevel + bobmods.modules.PollutionPenalty + 0.001 },
+      productivity = 2 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 ,
+      consumption = 2 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001 ,
+      pollution = 2 * bobmods.modules.PollutionPenaltyPerLevel + bobmods.modules.PollutionPenalty + 0.001 
     },
     limitation_message_key = "production-module-usable-only-on-intermediates",
     beacon_tint = {
@@ -383,11 +371,9 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      productivity = { bonus = 3 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
-      consumption = {
-        bonus = 3 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
-      },
-      pollution = { bonus = 3 * bobmods.modules.PollutionPenaltyPerLevel + bobmods.modules.PollutionPenalty + 0.001 },
+      productivity = 3 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
+      consumption = 3 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
+      pollution = 3 * bobmods.modules.PollutionPenaltyPerLevel + bobmods.modules.PollutionPenalty + 0.001
     },
     limitation_message_key = "production-module-usable-only-on-intermediates",
     beacon_tint = {
@@ -410,11 +396,9 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      productivity = { bonus = 4 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
-      consumption = {
-        bonus = 4 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
-      },
-      pollution = { bonus = 4 * bobmods.modules.PollutionPenaltyPerLevel + bobmods.modules.PollutionPenalty + 0.001 },
+      productivity = 4 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
+      consumption = 4 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
+      pollution = 4 * bobmods.modules.PollutionPenaltyPerLevel + bobmods.modules.PollutionPenalty + 0.001
     },
     limitation_message_key = "production-module-usable-only-on-intermediates",
     beacon_tint = {
@@ -437,11 +421,9 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      productivity = { bonus = 5 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
-      consumption = {
-        bonus = 5 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
-      },
-      pollution = { bonus = 5 * bobmods.modules.PollutionPenaltyPerLevel + bobmods.modules.PollutionPenalty + 0.001 },
+      productivity = 5 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
+      consumption = 5 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
+      pollution = 5 * bobmods.modules.PollutionPenaltyPerLevel + bobmods.modules.PollutionPenalty + 0.001
     },
     limitation_message_key = "production-module-usable-only-on-intermediates",
     beacon_tint = {
@@ -464,11 +446,9 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      productivity = { bonus = 6 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
-      consumption = {
-        bonus = 6 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
-      },
-      pollution = { bonus = 6 * bobmods.modules.PollutionPenaltyPerLevel + bobmods.modules.PollutionPenalty + 0.001 },
+      productivity = 6 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
+      consumption = 6 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
+      pollution = 6 * bobmods.modules.PollutionPenaltyPerLevel + bobmods.modules.PollutionPenalty + 0.001
     },
     limitation_message_key = "production-module-usable-only-on-intermediates",
     beacon_tint = {
@@ -491,11 +471,9 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      productivity = { bonus = 7 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
-      consumption = {
-        bonus = 7 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
-      },
-      pollution = { bonus = 7 * bobmods.modules.PollutionPenaltyPerLevel + bobmods.modules.PollutionPenalty + 0.001 },
+      productivity = 7 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
+      consumption = 7 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
+      pollution = 7 * bobmods.modules.PollutionPenaltyPerLevel + bobmods.modules.PollutionPenalty + 0.001
     },
     limitation_message_key = "production-module-usable-only-on-intermediates",
     beacon_tint = {
@@ -518,11 +496,9 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      productivity = { bonus = 8 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001 },
-      consumption = {
-        bonus = 8 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
-      },
-      pollution = { bonus = 8 * bobmods.modules.PollutionPenaltyPerLevel + bobmods.modules.PollutionPenalty + 0.001 },
+      productivity = 8 * bobmods.modules.ProductivityPerLevel + bobmods.modules.ProductivityBonus + 0.001,
+      consumption = 8 * bobmods.modules.ConsumptionPenaltyPerLevel + bobmods.modules.ConsumptionPenalty + 0.001,
+      pollution = 8 * bobmods.modules.PollutionPenaltyPerLevel + bobmods.modules.PollutionPenalty + 0.001
     },
     limitation_message_key = "production-module-usable-only-on-intermediates",
     beacon_tint = {
@@ -535,22 +511,14 @@ data:extend({
 })
 
 if settings.startup["bobmods-modules-productivityhasspeed"].value == true then
-  data.raw.module["productivity-module"].effect.speed =
-    { bonus = -1 * bobmods.modules.SpeedPenaltyPerLevel - bobmods.modules.SpeedPenalty }
-  data.raw.module["productivity-module-2"].effect.speed =
-    { bonus = -2 * bobmods.modules.SpeedPenaltyPerLevel - bobmods.modules.SpeedPenalty - 0.001 }
-  data.raw.module["productivity-module-3"].effect.speed =
-    { bonus = -3 * bobmods.modules.SpeedPenaltyPerLevel - bobmods.modules.SpeedPenalty - 0.001 }
-  data.raw.module["productivity-module-4"].effect.speed =
-    { bonus = -4 * bobmods.modules.SpeedPenaltyPerLevel - bobmods.modules.SpeedPenalty - 0.001 }
-  data.raw.module["productivity-module-5"].effect.speed =
-    { bonus = -5 * bobmods.modules.SpeedPenaltyPerLevel - bobmods.modules.SpeedPenalty - 0.001 }
-  data.raw.module["productivity-module-6"].effect.speed =
-    { bonus = -6 * bobmods.modules.SpeedPenaltyPerLevel - bobmods.modules.SpeedPenalty - 0.001 }
-  data.raw.module["productivity-module-7"].effect.speed =
-    { bonus = -7 * bobmods.modules.SpeedPenaltyPerLevel - bobmods.modules.SpeedPenalty - 0.001 }
-  data.raw.module["productivity-module-8"].effect.speed =
-    { bonus = -8 * bobmods.modules.SpeedPenaltyPerLevel - bobmods.modules.SpeedPenalty - 0.001 }
+  data.raw.module["productivity-module"].effect.speed = -1 * bobmods.modules.SpeedPenaltyPerLevel - bobmods.modules.SpeedPenalty
+  data.raw.module["productivity-module-2"].effect.speed = -2 * bobmods.modules.SpeedPenaltyPerLevel - bobmods.modules.SpeedPenalty - 0.001 
+  data.raw.module["productivity-module-3"].effect.speed = -3 * bobmods.modules.SpeedPenaltyPerLevel - bobmods.modules.SpeedPenalty - 0.001 
+  data.raw.module["productivity-module-4"].effect.speed = -4 * bobmods.modules.SpeedPenaltyPerLevel - bobmods.modules.SpeedPenalty - 0.001 
+  data.raw.module["productivity-module-5"].effect.speed = -5 * bobmods.modules.SpeedPenaltyPerLevel - bobmods.modules.SpeedPenalty - 0.001 
+  data.raw.module["productivity-module-6"].effect.speed = -6 * bobmods.modules.SpeedPenaltyPerLevel - bobmods.modules.SpeedPenalty - 0.001 
+  data.raw.module["productivity-module-7"].effect.speed = -7 * bobmods.modules.SpeedPenaltyPerLevel - bobmods.modules.SpeedPenalty - 0.001 
+  data.raw.module["productivity-module-8"].effect.speed = -8 * bobmods.modules.SpeedPenaltyPerLevel - bobmods.modules.SpeedPenalty - 0.001 
 end
 
 --[[Pollution Cleaning Modules]]
@@ -568,7 +536,9 @@ data:extend({
     order = "m-p-cl-1",
     stack_size = 100,
     default_request_amount = 10,
-    effect = { pollution = { bonus = -1 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 } },
+    effect = {
+      pollution = -1 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001
+    },
     beacon_tint = {
       primary = { r = 0.2, g = 0.5, b = 0.3 },
       secondary = { r = 0.4, g = 0.7, b = 0.5 },
@@ -588,7 +558,9 @@ data:extend({
     order = "m-p-cl-2",
     stack_size = 100,
     default_request_amount = 10,
-    effect = { pollution = { bonus = -2 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 } },
+    effect = {
+      pollution = -2 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+    },
     beacon_tint = {
       primary = { r = 0.2, g = 0.5, b = 0.3 },
       secondary = { r = 0.4, g = 0.7, b = 0.5 },
@@ -608,7 +580,9 @@ data:extend({
     order = "m-p-cl-3",
     stack_size = 100,
     default_request_amount = 10,
-    effect = { pollution = { bonus = -3 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 } },
+    effect = {
+      pollution = -3 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+    },
     beacon_tint = {
       primary = { r = 0.2, g = 0.5, b = 0.3 },
       secondary = { r = 0.4, g = 0.7, b = 0.5 },
@@ -628,7 +602,9 @@ data:extend({
     order = "m-p-cl-4",
     stack_size = 100,
     default_request_amount = 10,
-    effect = { pollution = { bonus = -4 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 } },
+    effect = {
+      pollution = -4 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+    },
     beacon_tint = {
       primary = { r = 0.2, g = 0.5, b = 0.3 },
       secondary = { r = 0.4, g = 0.7, b = 0.5 },
@@ -648,7 +624,9 @@ data:extend({
     order = "m-p-cl-5",
     stack_size = 100,
     default_request_amount = 10,
-    effect = { pollution = { bonus = -5 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 } },
+    effect = {
+      pollution = -5 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+    },
     beacon_tint = {
       primary = { r = 0.2, g = 0.5, b = 0.3 },
       secondary = { r = 0.4, g = 0.7, b = 0.5 },
@@ -668,7 +646,9 @@ data:extend({
     order = "m-p-cl-6",
     stack_size = 100,
     default_request_amount = 10,
-    effect = { pollution = { bonus = -6 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 } },
+    effect = {
+      pollution = -6 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+    },
     beacon_tint = {
       primary = { r = 0.2, g = 0.5, b = 0.3 },
       secondary = { r = 0.4, g = 0.7, b = 0.5 },
@@ -688,7 +668,9 @@ data:extend({
     order = "m-p-cl-7",
     stack_size = 100,
     default_request_amount = 10,
-    effect = { pollution = { bonus = -7 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 } },
+    effect = {
+      pollution = -7 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+    },
     beacon_tint = {
       primary = { r = 0.2, g = 0.5, b = 0.3 },
       secondary = { r = 0.4, g = 0.7, b = 0.5 },
@@ -708,7 +690,9 @@ data:extend({
     order = "m-p-cl-8",
     stack_size = 100,
     default_request_amount = 10,
-    effect = { pollution = { bonus = -8 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001 } },
+    effect = {
+      pollution = -8 * bobmods.modules.PollutionPerLevel - bobmods.modules.PollutionBonus - 0.001,
+    },
     beacon_tint = {
       primary = { r = 0.2, g = 0.5, b = 0.3 },
       secondary = { r = 0.4, g = 0.7, b = 0.5 },
@@ -734,8 +718,7 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      pollution = { bonus = bobmods.modules.PollutionCreatePerLevel + bobmods.modules.PollutionCreateBonus + 0.001 },
-    },
+      pollution = bobmods.modules.PollutionCreatePerLevel + bobmods.modules.PollutionCreateBonus + 0.001 },
     beacon_tint = {
       primary = { r = 0.4, g = 0.3, b = 0.2 },
       secondary = { r = 1, g = 0.5, b = 0 },
@@ -756,8 +739,7 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      pollution = { bonus = 2 * bobmods.modules.PollutionCreatePerLevel + bobmods.modules.PollutionCreateBonus + 0.001 },
-    },
+      pollution = 2 * bobmods.modules.PollutionCreatePerLevel + bobmods.modules.PollutionCreateBonus + 0.001 },
     beacon_tint = {
       primary = { r = 0.4, g = 0.3, b = 0.2 },
       secondary = { r = 1, g = 0.5, b = 0 },
@@ -778,8 +760,7 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      pollution = { bonus = 3 * bobmods.modules.PollutionCreatePerLevel + bobmods.modules.PollutionCreateBonus + 0.001 },
-    },
+      pollution = 3 * bobmods.modules.PollutionCreatePerLevel + bobmods.modules.PollutionCreateBonus + 0.001 },
     beacon_tint = {
       primary = { r = 0.4, g = 0.3, b = 0.2 },
       secondary = { r = 1, g = 0.5, b = 0 },
@@ -800,8 +781,7 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      pollution = { bonus = 4 * bobmods.modules.PollutionCreatePerLevel + bobmods.modules.PollutionCreateBonus + 0.001 },
-    },
+      pollution = 4 * bobmods.modules.PollutionCreatePerLevel + bobmods.modules.PollutionCreateBonus + 0.001 },
     beacon_tint = {
       primary = { r = 0.4, g = 0.3, b = 0.2 },
       secondary = { r = 1, g = 0.5, b = 0 },
@@ -822,8 +802,7 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      pollution = { bonus = 5 * bobmods.modules.PollutionCreatePerLevel + bobmods.modules.PollutionCreateBonus + 0.001 },
-    },
+      pollution = 5 * bobmods.modules.PollutionCreatePerLevel + bobmods.modules.PollutionCreateBonus + 0.001 },
     beacon_tint = {
       primary = { r = 0.4, g = 0.3, b = 0.2 },
       secondary = { r = 1, g = 0.5, b = 0 },
@@ -844,8 +823,7 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      pollution = { bonus = 6 * bobmods.modules.PollutionCreatePerLevel + bobmods.modules.PollutionCreateBonus + 0.001 },
-    },
+      pollution = 6 * bobmods.modules.PollutionCreatePerLevel + bobmods.modules.PollutionCreateBonus + 0.001 },
     beacon_tint = {
       primary = { r = 0.4, g = 0.3, b = 0.2 },
       secondary = { r = 1, g = 0.5, b = 0 },
@@ -866,8 +844,7 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      pollution = { bonus = 7 * bobmods.modules.PollutionCreatePerLevel + bobmods.modules.PollutionCreateBonus + 0.001 },
-    },
+      pollution = 7 * bobmods.modules.PollutionCreatePerLevel + bobmods.modules.PollutionCreateBonus + 0.001 },
     beacon_tint = {
       primary = { r = 0.4, g = 0.3, b = 0.2 },
       secondary = { r = 1, g = 0.5, b = 0 },
@@ -888,8 +865,7 @@ data:extend({
     stack_size = 100,
     default_request_amount = 10,
     effect = {
-      pollution = { bonus = 8 * bobmods.modules.PollutionCreatePerLevel + bobmods.modules.PollutionCreateBonus + 0.001 },
-    },
+      pollution = 8 * bobmods.modules.PollutionCreatePerLevel + bobmods.modules.PollutionCreateBonus + 0.001 },
     beacon_tint = {
       primary = { r = 0.4, g = 0.3, b = 0.2 },
       secondary = { r = 1, g = 0.5, b = 0 },

--- a/bobmodules/prototypes/recipe/beacon-updates.lua
+++ b/bobmodules/prototypes/recipe/beacon-updates.lua
@@ -1,4 +1,4 @@
-bobmods.lib.tech.remove_prerequisite("effect-transmission", "advanced-electronics-2")
+bobmods.lib.tech.remove_prerequisite("effect-transmission", "processing-unit")
 
 if data.raw.item["aluminium-plate"] then
   bobmods.lib.recipe.replace_ingredient("beacon-2", "steel-plate", "aluminium-plate")

--- a/bobmodules/prototypes/recipe/electronics-updates.lua
+++ b/bobmodules/prototypes/recipe/electronics-updates.lua
@@ -167,10 +167,10 @@ bobmods.lib.tech.add_recipe_unlock("efficiency-module", "efficiency-processor")
 bobmods.lib.tech.add_recipe_unlock("productivity-module", "productivity-processor")
 bobmods.lib.tech.add_recipe_unlock("pollution-clean-module-1", "pollution-clean-processor")
 bobmods.lib.tech.add_recipe_unlock("pollution-create-module-1", "pollution-create-processor")
-bobmods.lib.tech.add_recipe_unlock("advanced-electronics-2", "module-processor-board-2")
+bobmods.lib.tech.add_recipe_unlock("processing-unit", "module-processor-board-2")
 
 if data.raw.technology["advanced-electronics-3"] then
   bobmods.lib.tech.add_recipe_unlock("advanced-electronics-3", "module-processor-board-3")
 else
-  bobmods.lib.tech.add_recipe_unlock("advanced-electronics-2", "module-processor-board-3")
+  bobmods.lib.tech.add_recipe_unlock("processing-unit", "module-processor-board-3")
 end

--- a/bobmodules/prototypes/technology/module.lua
+++ b/bobmodules/prototypes/technology/module.lua
@@ -823,11 +823,11 @@ table.insert(
   { type = "unlock-recipe", recipe = "pollution-create-processor-3" }
 )
 
-table.insert(data.raw.technology["speed-module-3"].prerequisites, "advanced-electronics-2")
-table.insert(data.raw.technology["efficiency-module-3"].prerequisites, "advanced-electronics-2")
-table.insert(data.raw.technology["productivity-module-3"].prerequisites, "advanced-electronics-2")
-table.insert(data.raw.technology["pollution-clean-module-3"].prerequisites, "advanced-electronics-2")
-table.insert(data.raw.technology["pollution-create-module-3"].prerequisites, "advanced-electronics-2")
+table.insert(data.raw.technology["speed-module-3"].prerequisites, "processing-unit")
+table.insert(data.raw.technology["efficiency-module-3"].prerequisites, "processing-unit")
+table.insert(data.raw.technology["productivity-module-3"].prerequisites, "processing-unit")
+table.insert(data.raw.technology["pollution-clean-module-3"].prerequisites, "processing-unit")
+table.insert(data.raw.technology["pollution-create-module-3"].prerequisites, "processing-unit")
 
 if data.raw.technology["advanced-electronics-3"] then
   table.insert(data.raw.technology["speed-module-6"].prerequisites, "advanced-electronics-3")

--- a/bobmodules/settings.lua
+++ b/bobmodules/settings.lua
@@ -113,6 +113,14 @@ data:extend({
     maximum_value = 1,
     minimum_value = 0,
   },
+  {
+    type = "double-setting",
+    name = "bobmods-modules-perlevel-bonus-quality",
+    setting_type = "startup",
+    default_value = 0.5,
+    maximum_value = 1,
+    minimum_value = 0,
+  },
 
   {
     type = "double-setting",
@@ -174,6 +182,14 @@ data:extend({
   {
     type = "double-setting",
     name = "bobmods-modules-start-penalty-consumption",
+    setting_type = "startup",
+    default_value = 0,
+    maximum_value = 1,
+    minimum_value = 0,
+  },
+  {
+    type = "double-setting",
+    name = "bobmods-modules-start-bonus-quality",
     setting_type = "startup",
     default_value = 0,
     maximum_value = 1,


### PR DESCRIPTION
This is an update to Bob's Modules to be compatible with Factorio 2.0

I also decided to add quality bonuses to god modules, and in such a way that it can be reused for standard quality modules. However, the numbers may need to be tweaked.

Of course, I made sure to disable the quality bonus in case the player doesn't have the space age DLC.

I also changed the way "bobmods-modules-enableproductivitylimitation" (AKA the limitations on productivity) works, since 2.0 broke it, but it should be relatively invisible to the user.