### PR TITLE
Bob's classes 2.0

### DIFF
--- a/bobclasses/control.lua
+++ b/bobclasses/control.lua
@@ -75,7 +75,7 @@ function gui_add_title(gui, title, button_name, drag_target)
     type = "sprite-button",
     name = button_name,
     style = "frame_action_button",
-    sprite = "utility/close_white",
+    sprite = "utility/close",
   })
   if drag_target then
     gui.title_flow.title.drag_target = gui
@@ -1018,7 +1018,7 @@ function draw_buttons_row(player_index)
     gui.add({
       type = "sprite-button",
       name = "bob_avatar_rename",
-      sprite = "utility/rename_icon_normal",
+      sprite = "utility/rename_icon",
       style = "mod_gui_button_28",
     })
     gui.add({ type = "empty-widget", name = "filler", style = "bob_draggable_footer" })

--- a/bobclasses/data-updates.lua
+++ b/bobclasses/data-updates.lua
@@ -12,15 +12,15 @@ end
 
 --Fix for Space Age crafting category changes
 local categories = data.raw.character.character.crafting_categories
-data.raw.character["bob-character-miner"].crafting_categories = categories
-data.raw.character["bob-character-fighter"].crafting_categories = categories
-data.raw.character["bob-character-builder"].crafting_categories = categories
-data.raw.character["bob-character-balanced-2"].crafting_categories = categories
-data.raw.character["bob-character-miner-2"].crafting_categories = categories
-data.raw.character["bob-character-fighter-2"].crafting_categories = categories
-data.raw.character["bob-character-builder-2"].crafting_categories = categories
-data.raw.character["bob-character-engineer"].crafting_categories = categories
-data.raw.character["bob-character-prospector"].crafting_categories = categories
+data.raw.character["bob-character-miner"].crafting_categories = util.copy(categories)
+data.raw.character["bob-character-fighter"].crafting_categories = util.copy(categories)
+data.raw.character["bob-character-builder"].crafting_categories = util.copy(categories)
+data.raw.character["bob-character-balanced-2"].crafting_categories = util.copy(categories)
+data.raw.character["bob-character-miner-2"].crafting_categories = util.copy(categories)
+data.raw.character["bob-character-fighter-2"].crafting_categories = util.copy(categories)
+data.raw.character["bob-character-builder-2"].crafting_categories = util.copy(categories)
+data.raw.character["bob-character-engineer"].crafting_categories = util.copy(categories)
+data.raw.character["bob-character-prospector"].crafting_categories = util.copy(categories)
 
 table.insert(bobmods.classes.characters["bob-character-miner"].crafting_categories, "smelting")
 table.insert(bobmods.classes.characters["bob-character-miner-2"].crafting_categories, "smelting")

--- a/bobclasses/data-updates.lua
+++ b/bobclasses/data-updates.lua
@@ -10,6 +10,23 @@ for index, character in pairs(bobmods.classes.characters) do
   end
 end
 
+--Fix for Space Age crafting category changes
+local categories = data.raw.character.character.crafting_categories
+data.raw.character["bob-character-miner"].crafting_categories = categories
+data.raw.character["bob-character-fighter"].crafting_categories = categories
+data.raw.character["bob-character-builder"].crafting_categories = categories
+data.raw.character["bob-character-balanced-2"].crafting_categories = categories
+data.raw.character["bob-character-miner-2"].crafting_categories = categories
+data.raw.character["bob-character-fighter-2"].crafting_categories = categories
+data.raw.character["bob-character-builder-2"].crafting_categories = categories
+data.raw.character["bob-character-engineer"].crafting_categories = categories
+data.raw.character["bob-character-prospector"].crafting_categories = categories
+
+table.insert(bobmods.classes.characters["bob-character-miner"].crafting_categories, "smelting")
+table.insert(bobmods.classes.characters["bob-character-miner-2"].crafting_categories, "smelting")
+table.insert(bobmods.classes.characters["bob-character-engineer"].crafting_categories, "smelting")
+table.insert(bobmods.classes.characters["bob-character-prospector"].crafting_categories, "smelting")
+
 --if mixing furnace category exists, add it to characters with smelting category
 if data.raw["recipe-category"]["mixing-furnace"] then
   for index, character in pairs(bobmods.classes.characters) do

--- a/bobclasses/locale/en/bobclasses.cfg
+++ b/bobclasses/locale/en/bobclasses.cfg
@@ -1,15 +1,15 @@
 [entity-name]
-bob-character-miner=Miner class __ENTITY__character__
-bob-character-fighter=Fighter class __ENTITY__character__
-bob-character-builder=Builder class __ENTITY__character__
+bob-character-miner=Miner class character
+bob-character-fighter=Fighter class character
+bob-character-builder=Builder class character
 
-bob-character-balanced-2=Balanced 2 class __ENTITY__character__
-bob-character-miner-2=Miner 2 class __ENTITY__character__
-bob-character-fighter-2=Fighter 2 class __ENTITY__character__
-bob-character-builder-2=Builder 2 class __ENTITY__character__
+bob-character-balanced-2=Balanced 2 class character
+bob-character-miner-2=Miner 2 class character
+bob-character-fighter-2=Fighter 2 class character
+bob-character-builder-2=Builder 2 class character
 
-bob-character-engineer=Engineer class __ENTITY__character__
-bob-character-prospector=Prospector class __ENTITY__character__
+bob-character-engineer=Engineer class character
+bob-character-prospector=Prospector class character
 
 
 [item-name]
@@ -73,8 +73,8 @@ bob-character-prospector=The Prospector class is a combination of the Miner and 
 
 
 [technology-name]
-bodies=__ENTITY__character__ bodies
-balanced-body=Balanced class __ENTITY__character__ body
+bodies=Character bodies
+balanced-body=Balanced class character body
 miner-body=__ENTITY__bob-character-miner__ body
 fighter-body=__ENTITY__bob-character-fighter__ body
 builder-body=__ENTITY__bob-character-builder__ body

--- a/bobclasses/prototypes/bodies.lua
+++ b/bobclasses/prototypes/bodies.lua
@@ -1,3 +1,13 @@
+local body_drop_move = {
+  filename = "__base__/sound/item/armor-large-inventory-move.ogg",
+  volume = 0.7
+}
+
+local body_pick = {
+  filename = "__base__/sound/item/armor-large-inventory-pickup.ogg",
+  volume = 0.7
+}
+
 data:extend({
   {
     type = "item",
@@ -7,7 +17,10 @@ data:extend({
     subgroup = "bodies",
     order = "a[character]-1",
     place_result = "character",
-    stack_size = 10,
+    stack_size = 1,
+    drop_sound = body_drop_move,
+    inventory_move_sound = body_drop_move,
+    pick_sound = body_pick
   },
   {
     type = "item",
@@ -28,7 +41,10 @@ data:extend({
     subgroup = "bodies",
     order = "a[character]-1-miner",
     place_result = "bob-character-miner",
-    stack_size = 10,
+    stack_size = 1,
+    drop_sound = body_drop_move,
+    inventory_move_sound = body_drop_move,
+    pick_sound = body_pick
   },
   {
     type = "item",
@@ -49,7 +65,10 @@ data:extend({
     subgroup = "bodies",
     order = "a[character]-1-fighter",
     place_result = "bob-character-fighter",
-    stack_size = 10,
+    stack_size = 1,
+    drop_sound = body_drop_move,
+    inventory_move_sound = body_drop_move,
+    pick_sound = body_pick
   },
   {
     type = "item",
@@ -70,7 +89,10 @@ data:extend({
     subgroup = "bodies",
     order = "a[character]-1-builder",
     place_result = "bob-character-builder",
-    stack_size = 10,
+    stack_size = 1,
+    drop_sound = body_drop_move,
+    inventory_move_sound = body_drop_move,
+    pick_sound = body_pick
   },
 
   {
@@ -92,7 +114,10 @@ data:extend({
     subgroup = "bodies",
     order = "a[character]-2",
     place_result = "bob-character-balanced-2",
-    stack_size = 10,
+    stack_size = 1,
+    drop_sound = body_drop_move,
+    inventory_move_sound = body_drop_move,
+    pick_sound = body_pick
   },
   {
     type = "item",
@@ -119,7 +144,10 @@ data:extend({
     subgroup = "bodies",
     order = "a[character]-2-miner",
     place_result = "bob-character-miner-2",
-    stack_size = 10,
+    stack_size = 1,
+    drop_sound = body_drop_move,
+    inventory_move_sound = body_drop_move,
+    pick_sound = body_pick
   },
   {
     type = "item",
@@ -146,7 +174,10 @@ data:extend({
     subgroup = "bodies",
     order = "a[character]-2-fighter",
     place_result = "bob-character-fighter-2",
-    stack_size = 10,
+    stack_size = 1,
+    drop_sound = body_drop_move,
+    inventory_move_sound = body_drop_move,
+    pick_sound = body_pick
   },
   {
     type = "item",
@@ -173,7 +204,10 @@ data:extend({
     subgroup = "bodies",
     order = "a[character]-2-builder",
     place_result = "bob-character-builder-2",
-    stack_size = 10,
+    stack_size = 1,
+    drop_sound = body_drop_move,
+    inventory_move_sound = body_drop_move,
+    pick_sound = body_pick
   },
 
   {
@@ -195,7 +229,10 @@ data:extend({
     subgroup = "bodies",
     order = "a[character]-2-engineer",
     place_result = "bob-character-engineer",
-    stack_size = 10,
+    stack_size = 1,
+    drop_sound = body_drop_move,
+    inventory_move_sound = body_drop_move,
+    pick_sound = body_pick
   },
   {
     type = "item",
@@ -216,7 +253,10 @@ data:extend({
     subgroup = "bodies",
     order = "a[character]-2-prospector",
     place_result = "bob-character-prospector",
-    stack_size = 10,
+    stack_size = 1,
+    drop_sound = body_drop_move,
+    inventory_move_sound = body_drop_move,
+    pick_sound = body_pick
   },
 })
 

--- a/bobclasses/prototypes/parts.lua
+++ b/bobclasses/prototypes/parts.lua
@@ -1,3 +1,13 @@
+local bodypart_drop_move = {
+drop_sound = {
+  filename = "__base__/sound/item/armor-small-inventory-move.ogg",
+  volume = 0.7
+}
+local bodypart_pick = {
+  filename = "__base__/sound/item/armor-small-inventory-pickup.ogg",
+  volume = 0.7
+}
+
 data:extend({
   {
     type = "item",
@@ -7,6 +17,18 @@ data:extend({
     subgroup = "body-parts",
     order = "a[player]-brain",
     stack_size = 100,
+    drop_sound = {
+      filename = "__base__/sound/item/electric-small-inventory-move.ogg",
+      volume = 1
+    },
+    inventory_move_sound = {
+      filename = "__base__/sound/item/electric-small-inventory-move.ogg",
+      volume = 1
+    },
+    pick_sound = {
+      filename = "__base__/sound/item/electric-small-inventory-pickup.ogg",
+      volume = 0.7
+    },
   },
   {
     type = "item",
@@ -16,6 +38,9 @@ data:extend({
     subgroup = "body-parts",
     order = "a[player]-head",
     stack_size = 20,
+    drop_sound = bodypart_drop_move,
+    inventory_move_sound = bodypart_drop_move,
+    pick_sound = bodypart_pick,
   },
   {
     type = "item",
@@ -25,6 +50,9 @@ data:extend({
     subgroup = "body-parts",
     order = "a[player]-boots",
     stack_size = 20,
+    drop_sound = bodypart_drop_move,
+    inventory_move_sound = bodypart_drop_move,
+    pick_sound = bodypart_pick,
   },
   {
     type = "item",
@@ -34,6 +62,9 @@ data:extend({
     subgroup = "body-parts",
     order = "a[player]-gloves",
     stack_size = 20,
+    drop_sound = bodypart_drop_move,
+    inventory_move_sound = bodypart_drop_move,
+    pick_sound = bodypart_pick,
   },
   {
     type = "item",
@@ -43,6 +74,18 @@ data:extend({
     subgroup = "body-parts",
     order = "a[player]-power-core",
     stack_size = 20,
+    drop_sound = {
+      filename = "__base__/sound/item/reactor-inventory-move.ogg",
+      volume = 0.7
+    },
+    inventory_move_sound = {
+      filename = "__base__/sound/item/reactor-inventory-move.ogg",
+      volume = 0.7
+    },
+    pick_sound = {
+      filename = "__base__/sound/item/reactor-inventory-pickup.ogg",
+      volume = 0.6
+    },
   },
   {
     type = "item",
@@ -52,6 +95,18 @@ data:extend({
     subgroup = "body-parts",
     order = "a[player]-power-core",
     stack_size = 20,
+    drop_sound = {
+      filename = "__base__/sound/item/armor-large-inventory-move.ogg",
+      volume = 0.7
+    },
+    inventory_move_sound = {
+      filename = "__base__/sound/item/armor-large-inventory-move.ogg",
+      volume = 0.7
+    },
+    pick_sound = {
+      filename = "__base__/sound/item/armor-large-inventory-pickup.ogg",
+      volume = 0.7
+    },
   },
 
   {
@@ -137,6 +192,18 @@ data:extend({
     subgroup = "body-parts",
     order = "a[player]-brain-2",
     stack_size = 100,
+    drop_sound = {
+      filename = "__base__/sound/item/electric-small-inventory-move.ogg",
+      volume = 1
+    },
+    inventory_move_sound = {
+      filename = "__base__/sound/item/electric-small-inventory-move.ogg",
+      volume = 1
+    },
+    pick_sound = {
+      filename = "__base__/sound/item/electric-small-inventory-pickup.ogg",
+      volume = 0.7
+    },
   },
   {
     type = "item",
@@ -146,6 +213,9 @@ data:extend({
     subgroup = "body-parts",
     order = "a[player]-head-2",
     stack_size = 20,
+    drop_sound = bodypart_drop_move,
+    inventory_move_sound = bodypart_drop_move,
+    pick_sound = bodypart_pick,
   },
   {
     type = "item",
@@ -155,6 +225,9 @@ data:extend({
     subgroup = "body-parts",
     order = "a[player]-boots-2",
     stack_size = 20,
+    drop_sound = bodypart_drop_move,
+    inventory_move_sound = bodypart_drop_move,
+    pick_sound = bodypart_pick,
   },
   {
     type = "item",
@@ -164,6 +237,9 @@ data:extend({
     subgroup = "body-parts",
     order = "a[player]-gloves-2",
     stack_size = 20,
+    drop_sound = bodypart_drop_move,
+    inventory_move_sound = bodypart_drop_move,
+    pick_sound = bodypart_pick,
   },
   {
     type = "item",
@@ -173,6 +249,18 @@ data:extend({
     subgroup = "body-parts",
     order = "a[player]-power-core-2",
     stack_size = 20,
+    drop_sound = {
+      filename = "__base__/sound/item/armor-large-inventory-move.ogg",
+      volume = 0.7
+    },
+    inventory_move_sound = {
+      filename = "__base__/sound/item/armor-large-inventory-move.ogg",
+      volume = 0.7
+    },
+    pick_sound = {
+      filename = "__base__/sound/item/armor-large-inventory-pickup.ogg",
+      volume = 0.7
+    },
   },
 
   {

--- a/bobclasses/prototypes/parts.lua
+++ b/bobclasses/prototypes/parts.lua
@@ -1,5 +1,4 @@
 local bodypart_drop_move = {
-drop_sound = {
   filename = "__base__/sound/item/armor-small-inventory-move.ogg",
   volume = 0.7
 }


### PR DESCRIPTION
Update to make Bob's Classes loadable.

Updates a few sprites referenced in control.lua to their new names.
Adds item sounds.
Makes a few locale adjustments.
Reduces stack size for bodies to 1.
Added crafting_categories update to data-updates. This is to fix an issue with Space Age where because Space Age loads later, its new crafting categories are not added to Bob's Classes. Fixing this in the data-updates stage will also protect against any issues that may arise from other mods that add or modify crafting categories.

I'd like to change the name of the "brain" items for this one. It doesn't really make sense that the mind controlling a body could be run on just red circuit boards. I do see the reason behind making that change. However, from a flavor perspective, it would make more sense to me if these items were called "Body interface controller" or something along those lines.