### PR TITLE
Electronics: Improve item sounds

### DIFF
--- a/bobelectronics/prototypes/electronics.lua
+++ b/bobelectronics/prototypes/electronics.lua
@@ -305,16 +305,19 @@ data:extend({
     order = "c-a2[phenolic-board]",
     stack_size = 200,
     drop_sound = {
-      filename = "__base__/sound/item/solid-fuel-inventory-move.ogg",
+      filename = "__base__/sound/item/wood-inventory-move.ogg",
       volume = 0.7,
+      speed = 0.85,
     },
     inventory_move_sound = {
-      filename = "__base__/sound/item/solid-fuel-inventory-move.ogg",
+      filename = "__base__/sound/item/wood-inventory-move.ogg",
       volume = 0.7,
+      speed = 0.85,
     },
     pick_sound = {
-      filename = "__base__/sound/item/solid-fuel-inventory-pickup.ogg",
-      volume = 0.7,
+      filename = "__base__/sound/item/wood-inventory-pickup.ogg",
+      volume = 0.8,
+      speed = 0.85,
     },
   },
 
@@ -342,16 +345,19 @@ data:extend({
     order = "c-a3[fibreglass-board]",
     stack_size = 200,
     drop_sound = {
-      filename = "__base__/sound/item/solid-fuel-inventory-move.ogg",
-      volume = 0.7,
+      filename = "__base__/sound/item/wood-inventory-move.ogg",
+      volume = 0.85,
+      speed = 1.6,
     },
     inventory_move_sound = {
-      filename = "__base__/sound/item/solid-fuel-inventory-move.ogg",
-      volume = 0.7,
+      filename = "__base__/sound/item/wood-inventory-move.ogg",
+      volume = 0.85,
+      speed = 1.6,
     },
     pick_sound = {
-      filename = "__base__/sound/item/solid-fuel-inventory-pickup.ogg",
-      volume = 0.7,
+      filename = "__base__/sound/item/wood-inventory-pickup.ogg",
+      volume = 0.85,
+      speed = 1.6,
     },
   },
 
@@ -417,16 +423,19 @@ data:extend({
     order = "c-b2[circuit-board]",
     stack_size = 200,
     drop_sound = {
-      filename = "__base__/sound/item/planner-inventory-move.ogg",
+      filename = "__base__/sound/item/wood-inventory-move.ogg",
       volume = 0.7,
+      speed = 0.85,
     },
     inventory_move_sound = {
-      filename = "__base__/sound/item/planner-inventory-move.ogg",
+      filename = "__base__/sound/item/wood-inventory-move.ogg",
       volume = 0.7,
+      speed = 0.85,
     },
     pick_sound = {
-      filename = "__base__/sound/item/planner-inventory-pickup.ogg",
-      volume = 0.7,
+      filename = "__base__/sound/item/wood-inventory-pickup.ogg",
+      volume = 0.8,
+      speed = 0.85,
     },
   },
 
@@ -457,16 +466,19 @@ data:extend({
     order = "c-b3[superior-circuit-board]",
     stack_size = 200,
     drop_sound = {
-      filename = "__base__/sound/item/planner-inventory-move.ogg",
-      volume = 0.7,
+      filename = "__base__/sound/item/wood-inventory-move.ogg",
+      volume = 0.85,
+      speed = 1.6,
     },
     inventory_move_sound = {
-      filename = "__base__/sound/item/planner-inventory-move.ogg",
-      volume = 0.7,
+      filename = "__base__/sound/item/wood-inventory-move.ogg",
+      volume = 0.85,
+      speed = 1.6,
     },
     pick_sound = {
-      filename = "__base__/sound/item/planner-inventory-pickup.ogg",
-      volume = 0.7,
+      filename = "__base__/sound/item/wood-inventory-pickup.ogg",
+      volume = 0.85,
+      speed = 1.6,
     },
   },
 
@@ -497,16 +509,19 @@ data:extend({
     order = "c-b4[multi-layer-circuit-board]",
     stack_size = 200,
     drop_sound = {
-      filename = "__base__/sound/item/planner-inventory-move.ogg",
-      volume = 0.7,
+      filename = "__base__/sound/item/wood-inventory-move.ogg",
+      volume = 0.85,
+      speed = 1.6,
     },
     inventory_move_sound = {
-      filename = "__base__/sound/item/planner-inventory-move.ogg",
-      volume = 0.7,
+      filename = "__base__/sound/item/wood-inventory-move.ogg",
+      volume = 0.85,
+      speed = 1.6,
     },
     pick_sound = {
-      filename = "__base__/sound/item/planner-inventory-pickup.ogg",
-      volume = 0.7,
+      filename = "__base__/sound/item/wood-inventory-pickup.ogg",
+      volume = 0.85,
+      speed = 1.6,
     },
   },
 


### PR DESCRIPTION
Had a few items in Electronics that I couldn't find good options for item sounds. Notably, there's a lack of good glass-like sounds. A little research revealed that the game supports speed-changing for sound effects, and I was able to use this to improve the sounds for several items. Fortunately, there aren't many items that I need to go back to redo, and this will likely come in very handy when work on Plates begins.

This should be the last bit of polish Electronics needs, other than recycling updates, which is being handled in a different pull request.