### PR TITLE
Productivity removal

### DIFF
--- a/bobelectronics/prototypes/category.lua
+++ b/bobelectronics/prototypes/category.lua
@@ -25,13 +25,6 @@ data:extend({
   },
 
   {
-    type = "item-subgroup",
-    name = "bob-fluid",
-    group = "bob-fluid-products",
-    order = "a-a",
-  },
-
-  {
     type = "item-group",
     name = "bob-resource-products",
     order = "c-g",

--- a/bobelectronics/prototypes/chemicals.lua
+++ b/bobelectronics/prototypes/chemicals.lua
@@ -4,7 +4,7 @@ data:extend({
     name = "ferric-chloride-solution",
     icon = "__bobelectronics__/graphics/icons/ferric-chloride-solution.png",
     icon_size = 32,
-    subgroup = "bob-fluid",
+    subgroup = "fluid",
     default_temperature = 25,
     heat_capacity = "1kJ",
     base_color = { r = 0.7, g = 0.6, b = 0.2 },
@@ -18,7 +18,7 @@ data:extend({
     name = "ferric-chloride-solution",
     icon = "__bobelectronics__/graphics/icons/ferric-chloride-solution.png",
     icon_size = 32,
-    subgroup = "bob-fluid",
+    subgroup = "fluid",
     order = "b[fluid-chemistry]-a[ferric-chloride-solution]",
     category = "chemistry",
     enabled = false,
@@ -36,9 +36,13 @@ data:extend({
       tertiary = { r = 0.0, g = 0.7, b = 0.7, a = 0.000 },
     },
     allow_decomposition = false,
-    allow_productivity = true,
   },
 })
+
+if data.raw["item-subgroup"]["bob-fluid"] then
+  data.raw.recipe["ferric-chloride-solution"].subgroup = "bob-fluid"
+  data.raw.fluid["ferric-chloride-solution"].subgroup = "bob-fluid"
+end
 
 data:extend({
   {

--- a/bobplates/data-updates.lua
+++ b/bobplates/data-updates.lua
@@ -7,6 +7,10 @@ if data.raw["god-controller"] and data.raw["god-controller"]["default"] then
   data.raw["god-controller"]["default"].inventory_size = settings.startup["bobmods-plates-inventorysize"].value
 end
 
+--Sulfur update
+data.raw.recipe.sulfur.allow_productivity = false
+data.raw.recipe["sulfuric-acid"].allow_productivity = false
+
 --Electrolyser power
 if settings.startup["bobmods-plates-expensive-electrolysis"].value == true then
   if feature_flags["quality"] then

--- a/bobplates/prototypes/recipe/chemistry-recipe.lua
+++ b/bobplates/prototypes/recipe/chemistry-recipe.lua
@@ -142,7 +142,6 @@ data:extend({
       { type = "fluid", name = "oxygen", amount = 12.5 },
     },
     allow_decomposition = false,
-    allow_productivity = true,
   },
 
   {
@@ -169,7 +168,6 @@ data:extend({
       tertiary = { r = 0.25, g = 0.5, b = 0.25, a = 0.000 },
     },
     allow_decomposition = false,
-    allow_productivity = true,
   },
 
   {
@@ -192,7 +190,6 @@ data:extend({
       { type = "fluid", name = "hydrogen", amount = 10 },
     },
     allow_decomposition = false,
-    allow_productivity = true,
   },
 
   {
@@ -214,7 +211,6 @@ data:extend({
       { type = "fluid", name = "hydrogen", amount = 20 },
     },
     allow_decomposition = false,
-    allow_productivity = true,
   },
 
   {
@@ -239,7 +235,6 @@ data:extend({
       secondary = { r = 0.7, g = 0.0, b = 0.0, a = 0.000 },
       tertiary = { r = 0.8, g = 0.0, b = 1.0, a = 0.000 },
     },
-    allow_productivity = true,
   },
 
   {
@@ -264,7 +259,6 @@ data:extend({
       secondary = { r = 0.7, g = 0.7, b = 0.7, a = 0.000 },
       tertiary = { r = 0.2, g = 0.7, b = 0.0, a = 0.000 },
     },
-    allow_productivity = true,
   },
 
   {
@@ -289,7 +283,6 @@ data:extend({
       secondary = { r = 1.0, g = 0.7, b = 0.0, a = 0.000 },
       tertiary = { r = 0.0, g = 0.0, b = 0.7, a = 0.000 },
     },
-    allow_productivity = true,
   },
 
   {
@@ -315,7 +308,6 @@ data:extend({
       tertiary = { r = 0.0, g = 0.7, b = 0.7, a = 0.000 },
     },
     allow_decomposition = false,
-    allow_productivity = true,
   },
 
   {
@@ -367,7 +359,6 @@ data:extend({
       tertiary = { r = 0.564, g = 0.795, b = 0.000, a = 0.000 }, -- #8fca0000
     },
     allow_decomposition = false,
-    allow_productivity = true,
   },
 
   {
@@ -391,7 +382,6 @@ data:extend({
       tertiary = { r = 0.9, g = 0.9, b = 0.25, a = 0.000 },
     },
     allow_decomposition = false,
-    allow_productivity = true,
   },
 
   {
@@ -418,7 +408,6 @@ data:extend({
       tertiary = { r = 0.7, g = 0.7, b = 0.7, a = 0.000 },
     },
     allow_decomposition = false,
-    allow_productivity = true,
   },
 
   {
@@ -482,7 +471,6 @@ data:extend({
     },
     results = { { type = "item", name = "salt", amount = 1 } },
     allow_decomposition = false,
-    allow_productivity = true,
   },
 
   {
@@ -520,7 +508,6 @@ data:extend({
       tertiary = { r = 0.960, g = 0.806, b = 0.000, a = 0.000 }, -- #f4cd0000
     },
     allow_decomposition = false,
-    allow_productivity = true,
   },
 
   {
@@ -541,7 +528,6 @@ data:extend({
       secondary = { r = 0.7, g = 0.5, b = 0.0, a = 0.000 },
       tertiary = { r = 0.5, g = 0.05, b = 0.4, a = 0.000 },
     },
-    allow_productivity = true,
   },
 
   {
@@ -776,7 +762,6 @@ data:extend({
       secondary = { r = 1.0, g = 1.0, b = 1.0, a = 0.000 },
       tertiary = { r = 0.9, g = 0.9, b = 0.45, a = 0.000 },
     },
-    allow_productivity = true,
   },
 
   {
@@ -799,7 +784,6 @@ data:extend({
       tertiary = { r = 0.960, g = 0.806, b = 0.000 },
     },
     allow_decomposition = false,
-    allow_productivity = true,
   },
 
   {
@@ -826,7 +810,6 @@ data:extend({
       tertiary = { r = 0.564, g = 0.795, b = 0.000 },
     },
     allow_decomposition = false,
-    allow_productivity = true,
   },
 
   {
@@ -873,7 +856,6 @@ data:extend({
       { type = "fluid", name = "oxygen", amount = 12.5 },
     },
     allow_decomposition = false,
-    allow_productivity = true,
   },
 })
 
@@ -904,7 +886,6 @@ if not feature_flags["quality"] then
         secondary = { r = 0.0, g = 0.7, b = 0.7, a = 0.000 },
         tertiary = { r = 0.0, g = 0.0, b = 0.7, a = 0.000 },
       },
-      allow_productivity = true,
     },
 
     {

--- a/bobplates/prototypes/recipe/resource-recipe.lua
+++ b/bobplates/prototypes/recipe/resource-recipe.lua
@@ -249,7 +249,6 @@ data:extend({
       secondary = { r = 0.589, g = 0.540, b = 0.615, a = 0.361 },
       tertiary = { r = 0.469, g = 0.145, b = 0.695, a = 0.000 },
     },
-    allow_productivity = true,
   },
 
   {
@@ -273,3 +272,7 @@ data:extend({
     },
   },
 })
+
+data.raw.recipe["solid-fuel-from-petroleum-gas"].allow_productivity = false
+data.raw.recipe["solid-fuel-from-light-oil"].allow_productivity = false
+data.raw.recipe["solid-fuel-from-heavy-oil"].allow_productivity = false

--- a/bobrevamp/data.lua
+++ b/bobrevamp/data.lua
@@ -148,6 +148,7 @@ if settings.startup["bobmods-revamp-oil"].value == true then
       name = "sour-gas",
       icon = "__bobrevamp__/graphics/icons/sour-gas.png",
       icon_size = 64,
+      subgroup = "fluid",
       default_temperature = 25,
       heat_capacity = "0.1kJ",
       base_color = { r = 0.4, g = 0.1, b = 0.3 },
@@ -203,7 +204,6 @@ if settings.startup["bobmods-revamp-oil"].value == true then
         secondary = { r = 0.789, g = 0.540, b = 0.615 },
         tertiary = { r = 0.669, g = 0.145, b = 0.695 },
       },
-      allow_productivity = true,
     },
   })
 

--- a/bobrevamp/locale/en/bobrevamp.cfg
+++ b/bobrevamp/locale/en/bobrevamp.cfg
@@ -7,7 +7,7 @@ heat-shield=Heat shielding research
 low-density-structure=__ITEM__low-density-structure__ research
 thorium-power=Thorium nuclear power
 deuterium-power=Deuterium nuclear power
-rtg=Radio Thermoelectric Generator
+rtg=Radio thermoelectric generator
 
 
 [entity-name]
@@ -31,7 +31,7 @@ sodium-carbonate=Sodium carbonate
 sodium-bicarbonate=Sodium bicarbonate
 ammonium-chloride=Ammonium chloride
 sodium-cobaltate=Sodium cobaltate
-rtg=Radio Thermoelectric Generator
+rtg=Radio thermoelectric generator
 
 
 [fluid-name]
@@ -50,15 +50,15 @@ ammoniated-brine=Ammoniated brine
 
 
 [recipe-name]
-oil-processing-with-sulfur=Oil processing with Sulfur
-oil-processing-with-sulfur-dioxide=Oil processing with Sulfur dioxide
-oil-processing-with-sulfur-dioxide-2=Oil processing with Sulfur dioxide
-oil-processing-with-sulfur-dioxide-3=Oil processing with Sulfur dioxide
+oil-processing-with-sulfur=Oil processing with sulfur
+oil-processing-with-sulfur-dioxide=Oil processing with sulfur dioxide
+oil-processing-with-sulfur-dioxide-2=Oil processing with sulfur dioxide
+oil-processing-with-sulfur-dioxide-3=Oil processing with sulfur dioxide
 carbon-dioxide-oil-processing=Carbon dioxide mediated oil processing
 enriched-fuel-from-hydrazine=Enriched fuel block
 
-petroleum-gas-sweetening=__FLUID__petroleum-gas_ sweetening
-solid-fuel-from-sour-gas=Solid fuel from Sour gas
+petroleum-gas-sweetening=Petroleum gas sweetening
+solid-fuel-from-sour-gas=Solid fuel from sour gas
 
 bob-ammonium-chloride-recycling=Ammonium chloride recycling
 brine-electrolysis=Brine electrolysis
@@ -75,7 +75,7 @@ bobmods-revamp-nuclear=Nuclear power overhaul
 bobmods-revamp-old-oil=Oil and sulfur overhaul
 bobmods-revamp-oil=New oil and sulfur overhaul
 bobmods-revamp-hardmode=Extra chemistry
-bobmods-revamp-rtg=Radio Thermoelectric Generator
+bobmods-revamp-rtg=Radio thermoelectric generator
 
 
 [mod-setting-description]

--- a/bobrevamp/prototypes/hard-mode.lua
+++ b/bobrevamp/prototypes/hard-mode.lua
@@ -116,10 +116,9 @@ if bobmods.plates and settings.startup["bobmods-revamp-hardmode"].value == true 
       main_product = "sodium-chlorate",
       results = {
         { type = "item", name = "sodium-chlorate", amount = 1 },
-        { type = "fluid", name = "hydrogen", amount = 60, ignored_by_productivity = 60 },
+        { type = "fluid", name = "hydrogen", amount = 60 },
       },
       allow_decomposition = false,
-      allow_productivity = true,
     },
     {
       type = "recipe",
@@ -138,10 +137,9 @@ if bobmods.plates and settings.startup["bobmods-revamp-hardmode"].value == true 
       main_product = "sodium-perchlorate",
       results = {
         { type = "item", name = "sodium-perchlorate", amount = 1 },
-        { type = "fluid", name = "hydrogen", amount = 20, ignored_by_productivity = 20 },
+        { type = "fluid", name = "hydrogen", amount = 20 },
       },
       allow_decomposition = false,
-      allow_productivity = true,
     },
     {
       type = "recipe",
@@ -160,7 +158,7 @@ if bobmods.plates and settings.startup["bobmods-revamp-hardmode"].value == true 
       main_product = "lithium-perchlorate",
       results = {
         { type = "item", name = "lithium-perchlorate", amount = 1 },
-        { type = "item", name = "salt", amount = 1, ignored_by_productivity = 1 },
+        { type = "item", name = "salt", amount = 1 },
       },
       allow_decomposition = false,
     },
@@ -179,7 +177,6 @@ if bobmods.plates and settings.startup["bobmods-revamp-hardmode"].value == true 
       results = {
         { type = "fluid", name = "carbon-dioxide", amount = 25 },
       },
-      allow_productivity = true,
     },
     {
       type = "recipe",

--- a/bobrevamp/prototypes/rocket-fuel-updates.lua
+++ b/bobrevamp/prototypes/rocket-fuel-updates.lua
@@ -3,7 +3,7 @@ if data.raw.fluid.ammonia and data.raw.fluid.hydrazine and data.raw.fluid["dinit
     bobmods.lib.recipe.remove_result("hydrazine", "water")
     bobmods.lib.recipe.add_result(
       "hydrazine",
-      { type = "fluid", name = "pure-water", amount = 4, ignored_by_productivity = 4 }
+      { type = "fluid", name = "pure-water", amount = 4 }
     )
   end
 
@@ -11,6 +11,7 @@ if data.raw.fluid.ammonia and data.raw.fluid.hydrazine and data.raw.fluid["dinit
     { type = "fluid", name = "hydrazine", amount = 160 },
     { type = "fluid", name = "dinitrogen-tetroxide", amount = 80 },
   }
+  data.raw.recipe["rocket-fuel"].allow_productivity = false
 
   data.raw.recipe["rocket-fuel"].category = "chemistry"
   data.raw.recipe["rocket-fuel"].crafting_machine_tint = {
@@ -46,7 +47,7 @@ if data.raw.fluid.ammonia and data.raw.fluid.hydrazine and data.raw.fluid["dinit
       bobmods.lib.recipe.remove_result("nitric-oxide", "water")
       bobmods.lib.recipe.add_result(
         "nitric-oxide",
-        { type = "fluid", name = "pure-water", amount = 12, ignored_by_productivity = 12 }
+        { type = "fluid", name = "pure-water", amount = 12 }
       )
     end
 

--- a/bobrevamp/prototypes/rocket-fuel.lua
+++ b/bobrevamp/prototypes/rocket-fuel.lua
@@ -5,7 +5,7 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
       name = "ammonia",
       icon = "__bobrevamp__/graphics/icons/ammonia.png",
       icon_size = 64,
-      subgroup = "bob-fluid",
+      subgroup = "fluid",
       order = "a[fluid]-g[ammonia]",
       default_temperature = 15,
       max_temperature = 100,
@@ -20,7 +20,7 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
       name = "dinitrogen-tetroxide",
       icon = "__bobrevamp__/graphics/icons/dinitrogen-tetroxide.png",
       icon_size = 64,
-      subgroup = "bob-fluid",
+      subgroup = "fluid",
       order = "a[fluid]-g[dinitrogen-tetroxide]",
       default_temperature = 15,
       max_temperature = 100,
@@ -35,7 +35,7 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
       name = "hydrazine",
       icon = "__bobrevamp__/graphics/icons/hydrazine.png",
       icon_size = 64,
-      subgroup = "bob-fluid",
+      subgroup = "fluid",
       order = "a[fluid]-g[hydrazine]",
       default_temperature = 15,
       max_temperature = 100,
@@ -52,7 +52,7 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
       name = "hydrogen-peroxide",
       icon = "__bobrevamp__/graphics/icons/hydrogen-peroxide.png",
       icon_size = 64,
-      subgroup = "bob-fluid",
+      subgroup = "fluid",
       order = "a[fluid]-g[hydrogen-peroxide]",
       default_temperature = 15,
       max_temperature = 100,
@@ -70,7 +70,7 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
         name = "nitrogen-dioxide",
         icon = "__bobrevamp__/graphics/icons/nitrogen-dioxide.png",
         icon_size = 64,
-        subgroup = "bob-fluid",
+        subgroup = "fluid",
         order = "a[fluid]-g[nitrogen-dioxide]",
         default_temperature = 25,
         max_temperature = 100,
@@ -91,7 +91,7 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
       order = "b[fluid-chemistry]-b[ammonia]",
       energy_required = 1,
       category = "chemistry",
-      subgroup = "bob-fluid",
+      subgroup = "fluid",
       enabled = false,
       ingredients = {
         { type = "fluid", name = "nitrogen", amount = 10 },
@@ -106,7 +106,6 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
         secondary = { r = 0.7, g = 0.7, b = 0.7, a = 0.000 },
         tertiary = { r = 0.5, g = 0.5, b = 1.0, a = 0.000 },
       },
-      allow_productivity = true,
     },
 
     {
@@ -117,7 +116,7 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
       order = "b[fluid-chemistry]-b[hydrogen-peroxide]",
       energy_required = 1,
       category = "chemistry",
-      subgroup = "bob-fluid",
+      subgroup = "fluid",
       enabled = false,
       ingredients = {
         { type = "fluid", name = "hydrogen", amount = 16 },
@@ -132,7 +131,6 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
         secondary = { r = 0.8, g = 0.0, b = 0.0, a = 0.000 },
         tertiary = { r = 0.0, g = 0.5, b = 1.0, a = 0.000 },
       },
-      allow_productivity = true,
     },
 
     {
@@ -143,7 +141,7 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
       order = "b[fluid-chemistry]-b[hydrazine]",
       energy_required = 1,
       category = "chemistry",
-      subgroup = "bob-fluid",
+      subgroup = "fluid",
       enabled = false,
       ingredients = {
         { type = "fluid", name = "ammonia", amount = 20 },
@@ -151,7 +149,7 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
       },
       results = {
         { type = "fluid", name = "hydrazine", amount = 8 },
-        { type = "fluid", name = "water", amount = 4, ignored_by_productivity = 4 },
+        { type = "fluid", name = "water", amount = 4 },
       },
       main_product = "hydrazine",
       crafting_machine_tint = {
@@ -159,7 +157,6 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
         secondary = { r = 0.0, g = 0.5, b = 1.0, a = 0.000 },
         tertiary = { r = 0.7, g = 0.7, b = 1.0, a = 0.000 },
       },
-      allow_productivity = true,
     },
 
     {
@@ -170,7 +167,7 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
       order = "b[fluid-chemistry]-b[nitrogen-dioxide]",
       energy_required = 1,
       category = "chemistry",
-      subgroup = "bob-fluid",
+      subgroup = "fluid",
       enabled = false,
       ingredients = {
         { type = "fluid", name = "nitrogen", amount = 10 },
@@ -185,7 +182,6 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
         secondary = { r = 0.7, g = 0.0, b = 0.0, a = 0.000 },
         tertiary = { r = 0.8, g = 0.0, b = 1.0, a = 0.000 },
       },
-      allow_productivity = true,
     },
 
     {
@@ -196,7 +192,7 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
       order = "b[fluid-chemistry]-b[dinitrogen-tetroxide]",
       energy_required = 1,
       category = "chemistry",
-      subgroup = "bob-fluid",
+      subgroup = "fluid",
       enabled = false,
       ingredients = {
         { type = "fluid", name = "nitrogen-dioxide", amount = 20 },
@@ -210,12 +206,24 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
         secondary = { r = 0.7, g = 0.7, b = 0.7, a = 0.000 },
         tertiary = { r = 0.7, g = 0.7, b = 0.3, a = 0.000 },
       },
-      allow_productivity = true,
     },
   })
 
   if bobmods.plates.make_void_fluid_recipe then
     bobmods.plates.make_void_fluid_recipe("ammonia", 25, 15)
+  end
+
+  if data.raw["item-subgroup"]["bob-fluid"] then
+    data.raw.fluid.ammonia.subgroup = "bob-fluid"
+    data.raw.fluid["dinitrogen-tetroxide"].subgroup = "bob-fluid"
+    data.raw.fluid.hydrazine.subgroup = "bob-fluid"
+    data.raw.fluid["hydrogen-peroxide"].subgroup = "bob-fluid"
+    data.raw.fluid["nitrogen-dioxide"].subgroup = "bob-fluid"
+    data.raw.recipe.ammonia.subgroup = "bob-fluid"
+    data.raw.recipe["hydrogen-peroxide"].subgroup = "bob-fluid"
+    data.raw.recipe.hydrazine.subgroup = "bob-fluid"
+    data.raw.recipe["nitrogen-dioxide"].subgroup = "bob-fluid"
+    data.raw.recipe["dinitrogen-tetroxide"].subgroup = "bob-fluid"
   end
 
   if settings.startup["bobmods-revamp-hardmode"].value == true then
@@ -225,7 +233,7 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
         name = "nitric-oxide",
         icon = "__bobrevamp__/graphics/icons/nitric-oxide.png",
         icon_size = 64,
-        subgroup = "bob-fluid",
+        subgroup = "fluid",
         order = "a[fluid]-g[nitric-oxide]",
         default_temperature = 15,
         max_temperature = 100,
@@ -243,7 +251,7 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
         order = "b[fluid-chemistry]-b[nitric-oxide]",
         energy_required = 1,
         category = "chemistry",
-        subgroup = "bob-fluid",
+        subgroup = "fluid",
         enabled = false,
         ingredients = {
           { type = "fluid", name = "ammonia", amount = 20 },
@@ -251,7 +259,7 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
         },
         results = {
           { type = "fluid", name = "nitric-oxide", amount = 20 },
-          { type = "fluid", name = "water", amount = 12, ignored_by_productivity = 12 },
+          { type = "fluid", name = "water", amount = 12 },
         },
         main_product = "nitric-oxide",
         crafting_machine_tint = {
@@ -259,7 +267,6 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
           secondary = { r = 0.8, g = 0.0, b = 0.0, a = 0.000 },
           tertiary = { r = 1.0, g = 0.0, b = 1.0, a = 0.000 },
         },
-        allow_productivity = true,
       },
 
       {
@@ -270,7 +277,7 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
         order = "b[fluid-chemistry]-b[nitrogen-dioxide]",
         energy_required = 1,
         category = "chemistry",
-        subgroup = "bob-fluid",
+        subgroup = "fluid",
         enabled = false,
         ingredients = {
           { type = "fluid", name = "nitric-oxide", amount = 20 },
@@ -285,9 +292,15 @@ if data.raw.fluid.hydrogen and data.raw.fluid.oxygen and data.raw.fluid.nitrogen
           secondary = { r = 0.7, g = 0.0, b = 0.0, a = 0.000 },
           tertiary = { r = 0.8, g = 0.0, b = 1.0, a = 0.000 },
         },
-        allow_productivity = true,
       },
     })
+
+    if data.raw["item-subgroup"]["bob-fluid"] then
+      data.raw.fluid["nitric-oxide"].subgroup = "bob-fluid"
+      data.raw.recipe["nitric-oxide"].subgroup = "bob-fluid"
+      data.raw.recipe["nitrogen-dioxide"].subgroup = "bob-fluid"
+    end
+
   end
 
   if data.raw.item["enriched-fuel"] then

--- a/bobrevamp/prototypes/rtg-updates.lua
+++ b/bobrevamp/prototypes/rtg-updates.lua
@@ -3,7 +3,7 @@ if bobmods.plates and settings.startup["bobmods-revamp-rtg"].value == true then
     data.raw.recipe["sodium-cobaltate"].emissions_multiplier = 0.2
     bobmods.lib.recipe.add_result(
       "sodium-cobaltate",
-      { type = "fluid", name = "carbon-dioxide", amount = 150, ignored_by_productivity = 150 }
+      { type = "fluid", name = "carbon-dioxide", amount = 150 }
     )
 
     if data.raw.fluid["pure-water"] then

--- a/bobrevamp/prototypes/rtg.lua
+++ b/bobrevamp/prototypes/rtg.lua
@@ -112,7 +112,6 @@ if bobmods.plates and settings.startup["bobmods-revamp-rtg"].value == true then
           secondary = { r = 0.5, g = 0.5, b = 0.8, a = 0.000 },
           tertiary = { r = 0.4, g = 0.4, b = 0.8, a = 0.000 },
         },
-        allow_productivity = true,
       },
       {
         type = "recipe",
@@ -135,7 +134,6 @@ if bobmods.plates and settings.startup["bobmods-revamp-rtg"].value == true then
           secondary = { r = 0.5, g = 0.5, b = 0.8, a = 0.000 },
           tertiary = { r = 0.4, g = 0.4, b = 0.8, a = 0.000 },
         },
-        allow_productivity = true,
       },
       {
         type = "recipe",
@@ -153,7 +151,7 @@ if bobmods.plates and settings.startup["bobmods-revamp-rtg"].value == true then
         },
         results = {
           { type = "item", name = "sodium-bicarbonate", amount = 1 },
-          { type = "item", name = "ammonium-chloride", amount = 1, ignored_by_productivity = 1 },
+          { type = "item", name = "ammonium-chloride", amount = 1 },
         },
         main_product = "sodium-bicarbonate",
         crafting_machine_tint = {
@@ -161,7 +159,6 @@ if bobmods.plates and settings.startup["bobmods-revamp-rtg"].value == true then
           secondary = { r = 0.7, g = 0.7, b = 0.7, a = 0.000 },
           tertiary = { r = 0.4, g = 0.4, b = 0.4, a = 0.000 },
         },
-        allow_productivity = true,
       },
       {
         type = "recipe",
@@ -178,7 +175,7 @@ if bobmods.plates and settings.startup["bobmods-revamp-rtg"].value == true then
         },
         results = {
           { type = "item", name = "sodium-carbonate", amount = 1 },
-          { type = "fluid", name = "water", amount = 10, fluidbox_index = 1, ignored_by_productivity = 10 },
+          { type = "fluid", name = "water", amount = 10, fluidbox_index = 1 },
           { type = "fluid", name = "carbon-dioxide", amount = 25, fluidbox_index = 2 },
         },
         main_product = "sodium-carbonate",
@@ -187,7 +184,6 @@ if bobmods.plates and settings.startup["bobmods-revamp-rtg"].value == true then
           secondary = { r = 0.0, g = 0.5, b = 0.8, a = 0.000 },
           tertiary = { r = 0.8, g = 0.4, b = 0.4, a = 0.000 },
         },
-        allow_productivity = true,
       },
       {
         type = "recipe",
@@ -262,7 +258,6 @@ if bobmods.plates and settings.startup["bobmods-revamp-rtg"].value == true then
           secondary = { r = 0.7, g = 0.7, b = 0.7, a = 0.000 },
           tertiary = { r = 0.4, g = 0.4, b = 0.4, a = 0.000 },
         },
-        allow_productivity = true,
       },
     })
   end
@@ -317,7 +312,7 @@ if bobmods.plates and settings.startup["bobmods-revamp-rtg"].value == true then
       },
       results = {
         { type = "item", name = "sodium-cobaltate", amount = 5 },
-        { type = "fluid", name = "oxygen", amount = 200, ignored_by_productivity = 200 },
+        { type = "fluid", name = "oxygen", amount = 200 },
       },
       main_product = "sodium-cobaltate",
       crafting_machine_tint = {
@@ -325,7 +320,6 @@ if bobmods.plates and settings.startup["bobmods-revamp-rtg"].value == true then
         secondary = { r = 0.7, g = 0.7, b = 0.7, a = 0.000 },
         tertiary = { r = 0.8, g = 0.4, b = 0.4, a = 0.000 },
       },
-      allow_productivity = true,
     },
     {
       type = "recipe",

--- a/bobwarfare/prototypes/item/fluid.lua
+++ b/bobwarfare/prototypes/item/fluid.lua
@@ -10,12 +10,10 @@ if data.raw.fluid["nitric-acid"] then
       max_temperature = 100,
       icon = "__bobwarfare__/graphics/icons/sulfuric-nitric-acid.png",
       icon_size = 32,
+      subgroup = "fluid",
       order = "a[fluid]-g[sulfuric-nitric-acid]",
     },
   })
-  if data.raw["item-subgroup"]["bob-fluid"] then
-    data.raw.fluid["sulfuric-nitric-acid"].subgroup = "bob-fluid"
-  end
 end
 
 data:extend({
@@ -29,6 +27,7 @@ data:extend({
     max_temperature = 100,
     icon = "__bobwarfare__/graphics/icons/nitroglycerin.png",
     icon_size = 64,
+    subgroup = "fluid",
     order = "a[fluid]-g[nitroglycerin]",
   },
 
@@ -42,11 +41,8 @@ data:extend({
     max_temperature = 100,
     icon = "__bobwarfare__/graphics/icons/glycerol.png",
     icon_size = 64,
+    subgroup = "fluid",
     order = "a[fluid]-g[glycerol]",
     fuel_value = "730kJ", --"1.46MJ"
   },
 })
-if data.raw["item-subgroup"]["bob-fluid"] then
-  data.raw.fluid["nitroglycerin"].subgroup = "bob-fluid"
-  data.raw.fluid["glycerol"].subgroup = "bob-fluid"
-end

--- a/bobwarfare/prototypes/recipe/fluid-recipe.lua
+++ b/bobwarfare/prototypes/recipe/fluid-recipe.lua
@@ -17,7 +17,6 @@ if data.raw.fluid["nitric-acid"] then
       icon = "__bobwarfare__/graphics/icons/sulfuric-nitric-acid.png",
       icon_size = 32,
       order = "b[fluid-chemistry]-b[sulfuric-nitric-acid]",
-      allow_productivity = true,
     },
   })
 end
@@ -39,7 +38,6 @@ data:extend({
     icon = "__bobwarfare__/graphics/icons/glycerol.png",
     icon_size = 64,
     order = "b[fluid-chemistry]-b[glycerol]",
-    allow_productivity = true,
   },
 
   {
@@ -59,14 +57,16 @@ data:extend({
     icon = "__bobwarfare__/graphics/icons/nitroglycerin.png",
     icon_size = 64,
     order = "b[fluid-chemistry]-b[nitroglycerin]",
-    allow_productivity = true,
   },
 })
 
 if data.raw["item-subgroup"]["bob-fluid"] then
   if data.raw.recipe["sulfuric-nitric-acid"] then
     data.raw.recipe["sulfuric-nitric-acid"].subgroup = "bob-fluid"
+    data.raw.fluid["sulfuric-nitric-acid"].subgroup = "bob-fluid"
   end
   data.raw.recipe["glycerol"].subgroup = "bob-fluid"
   data.raw.recipe["nitroglycerin"].subgroup = "bob-fluid"
+  data.raw.fluid["glycerol"].subgroup = "bob-fluid"
+  data.raw.fluid["nitroglycerin"].subgroup = "bob-fluid"
 end


### PR DESCRIPTION
Resolves #253. Removes productivity from various pure chemistry recipes. Fixes issues like being able to use productivity to endlessly get more and more sulfur by going back and forth between sulfur and hydrogen sulfide.

Also removed productivity from vanilla sulfur/sulfuric acid and solid fuel, to match enriched fuel not having productivity. It makes more sense this way, given how various fluids also have set fuel_values.

Also made all instances of the subgroup bob-fluids conditional, unless they're in Plates or dependent on Plates.