### PR TITLE
Add tungsten gears

### DIFF
--- a/bobmining/prototypes/areadrill-updates.lua
+++ b/bobmining/prototypes/areadrill-updates.lua
@@ -37,14 +37,9 @@ if settings.startup["bobmods-mining-areadrills"].value == true then
     end
   end
 
-  if data.raw.item["bob-titanium-gear-wheel"] then
-    bobmods.lib.recipe.replace_ingredient("bob-area-mining-drill-3", "iron-gear-wheel", "bob-titanium-gear-wheel")
-    bobmods.lib.tech.add_prerequisite("bob-area-drills-4", "bob-titanium-processing")
-  else
-    if data.raw.item["bob-tungsten-gear-wheel"] then
-      bobmods.lib.recipe.replace_ingredient("bob-area-mining-drill-3", "iron-gear-wheel", "bob-tungsten-gear-wheel")
-      bobmods.lib.tech.add_prerequisite("bob-area-drills-4", "bob-tungsten-processing")
-    end
+  if data.raw.item["bob-tungsten-gear-wheel"] then
+    bobmods.lib.recipe.replace_ingredient("bob-area-mining-drill-3", "iron-gear-wheel", "bob-tungsten-gear-wheel")
+    bobmods.lib.tech.add_prerequisite("bob-area-drills-4", "bob-tungsten-processing")
   end
 
   if data.raw.item["bob-advanced-processing-unit"] then

--- a/bobmining/prototypes/drill-updates.lua
+++ b/bobmining/prototypes/drill-updates.lua
@@ -37,14 +37,9 @@ if settings.startup["bobmods-mining-miningdrills"].value == true then
     end
   end
 
-  if data.raw.item["bob-titanium-gear-wheel"] then
-    bobmods.lib.recipe.replace_ingredient("bob-mining-drill-3", "iron-gear-wheel", "bob-titanium-gear-wheel")
-    bobmods.lib.tech.add_prerequisite("bob-drills-4", "bob-titanium-processing")
-  else
-    if data.raw.item["bob-tungsten-gear-wheel"] then
-      bobmods.lib.recipe.replace_ingredient("bob-mining-drill-3", "iron-gear-wheel", "bob-tungsten-gear-wheel")
-      bobmods.lib.tech.add_prerequisite("bob-drills-4", "bob-tungsten-processing")
-    end
+  if data.raw.item["bob-tungsten-gear-wheel"] then
+    bobmods.lib.recipe.replace_ingredient("bob-mining-drill-3", "iron-gear-wheel", "bob-tungsten-gear-wheel")
+    bobmods.lib.tech.add_prerequisite("bob-drills-4", "bob-tungsten-processing")
   end
 
   if data.raw.item["bob-advanced-processing-unit"] then

--- a/bobpower/prototypes/recipe/fluid-generator-updates.lua
+++ b/bobpower/prototypes/recipe/fluid-generator-updates.lua
@@ -82,8 +82,8 @@ if settings.startup["bobmods-power-fluidgenerator"].value == true then
     bobmods.lib.recipe.add_ingredient("fluid-generator-3", { type = "item", name = "iron-gear-wheel", amount = 10 })
   end
 
-  if data.raw.item["bob-titanium-gear-wheel"] then
-    bobmods.lib.recipe.replace_ingredient("fluid-generator-3", "iron-gear-wheel", "bob-titanium-gear-wheel")
+  if data.raw.item["bob-tungsten-gear-wheel"] then
+    bobmods.lib.recipe.replace_ingredient("fluid-generator-3", "iron-gear-wheel", "bob-tungsten-gear-wheel")
   elseif data.raw.item["bob-steel-gear-wheel"] then
     bobmods.lib.recipe.replace_ingredient("fluid-generator-3", "iron-gear-wheel", "bob-steel-gear-wheel")
   end

--- a/bobpower/prototypes/recipe/steam-engines-updates.lua
+++ b/bobpower/prototypes/recipe/steam-engines-updates.lua
@@ -65,17 +65,12 @@ if settings.startup["bobmods-power-steam"].value == true then
     end
   end
 
-  if data.raw.item["bob-titanium-gear-wheel"] then
-    bobmods.lib.recipe.replace_ingredient("steam-engine-4", "iron-gear-wheel", "bob-titanium-gear-wheel")
-    bobmods.lib.tech.add_prerequisite("bob-steam-engine-4", "bob-titanium-processing")
+  if data.raw.item["bob-tungsten-gear-wheel"] then
+    bobmods.lib.recipe.replace_ingredient("steam-engine-4", "iron-gear-wheel", "bob-tungsten-gear-wheel")
+    bobmods.lib.tech.add_prerequisite("bob-steam-engine-4", "bob-tungsten-processing")
   else
-    if data.raw.item["bob-tungsten-gear-wheel"] then
-      bobmods.lib.recipe.replace_ingredient("steam-engine-4", "iron-gear-wheel", "bob-tungsten-gear-wheel")
-      bobmods.lib.tech.add_prerequisite("bob-steam-engine-4", "bob-tungsten-processing")
-    else
-      if data.raw.item["bob-steel-gear-wheel"] then
-        bobmods.lib.recipe.replace_ingredient("steam-engine-4", "iron-gear-wheel", "bob-steel-gear-wheel")
-      end
+    if data.raw.item["bob-steel-gear-wheel"] then
+      bobmods.lib.recipe.replace_ingredient("steam-engine-4", "iron-gear-wheel", "bob-steel-gear-wheel")
     end
   end
 

--- a/bobpower/prototypes/recipe/steam-turbines-updates.lua
+++ b/bobpower/prototypes/recipe/steam-turbines-updates.lua
@@ -50,17 +50,12 @@ if settings.startup["bobmods-power-steam"].value == true then
     end
   end
 
-  if data.raw.item["bob-titanium-gear-wheel"] then
-    bobmods.lib.recipe.replace_ingredient("steam-turbine-2", "iron-gear-wheel", "bob-titanium-gear-wheel")
-    bobmods.lib.tech.add_prerequisite("bob-steam-turbine-2", "bob-titanium-processing")
+  if data.raw.item["bob-tungsten-gear-wheel"] then
+    bobmods.lib.recipe.replace_ingredient("steam-turbine-2", "iron-gear-wheel", "bob-tungsten-gear-wheel")
+    bobmods.lib.tech.add_prerequisite("bob-steam-turbine-2", "bob-tungsten-processing")
   else
-    if data.raw.item["bob-tungsten-gear-wheel"] then
-      bobmods.lib.recipe.replace_ingredient("steam-turbine-2", "iron-gear-wheel", "bob-tungsten-gear-wheel")
-      bobmods.lib.tech.add_prerequisite("bob-steam-turbine-2", "bob-tungsten-processing")
-    else
-      if data.raw.item["bob-steel-gear-wheel"] then
-        bobmods.lib.recipe.replace_ingredient("steam-turbine-2", "iron-gear-wheel", "bob-steel-gear-wheel")
-      end
+    if data.raw.item["bob-steel-gear-wheel"] then
+      bobmods.lib.recipe.replace_ingredient("steam-turbine-2", "iron-gear-wheel", "bob-steel-gear-wheel")
     end
   end
 


### PR DESCRIPTION
Changes recipe updates around a bit so that tungsten gears will now be the first pick for mining drill 4s, steam engine 4, steam turbine 2, and fluid generator 3, all replacing titanium gears. Most of these already had tungsten gears as a fallback, so they were obvious picks.

It's a little difficult to pick and choose between these two gears, since neither titanium nor tungsten are particularly well suited to being used that way. But titanium loses a lot of its strength at high temperatures, which would increase the risk of mechanical failure in a gear, so switching high-temperature power generators to tungsten makes sense. Titanium is also not very good at dealing with the kind of wear and tear that would result from the highly irregular grinding of ore.