### PR TITLE
Shrink elemental ammo splash radius from 3 to 2

### DIFF
--- a/bobwarfare/prototypes/item/ammo.lua
+++ b/bobwarfare/prototypes/item/ammo.lua
@@ -177,7 +177,7 @@ data:extend({
               type = "nested-result",
               action = {
                 type = "area",
-                radius = 3,
+                radius = 2,
                 action_delivery = {
                   type = "instant",
                   target_effects = {
@@ -235,7 +235,7 @@ data:extend({
               type = "nested-result",
               action = {
                 type = "area",
-                radius = 3,
+                radius = 2,
                 action_delivery = {
                   type = "instant",
                   target_effects = {
@@ -289,7 +289,7 @@ data:extend({
               type = "nested-result",
               action = {
                 type = "area",
-                radius = 3,
+                radius = 2,
                 action_delivery = {
                   type = "instant",
                   target_effects = {
@@ -347,7 +347,7 @@ data:extend({
               type = "nested-result",
               action = {
                 type = "area",
-                radius = 3,
+                radius = 2,
                 action_delivery = {
                   type = "instant",
                   target_effects = {
@@ -1386,7 +1386,7 @@ data:extend({
               type = "nested-result",
               action = {
                 type = "area",
-                radius = 3,
+                radius = 2,
                 action_delivery = {
                   type = "instant",
                   target_effects = {


### PR DESCRIPTION
I knew I was forgetting to do something. Shrinking the splash radius of elemental ammo from 3 to 2 will further balance the ammo types, and incidentally, actually make the ones with splash damage easier to use, since they won't obliterate your own defenses quite as much.