### PR TITLE
Final hydrogen fix

### DIFF
--- a/bobplates/data-updates.lua
+++ b/bobplates/data-updates.lua
@@ -18,9 +18,23 @@ if settings.startup["bobmods-plates-expensive-electrolysis"].value == true then
     data.raw.fluid["bob-deuterium"].fuel_value = "35kJ"
     data.raw.recipe["bob-water-electrolysis"].energy_required = 2
     data.raw.recipe["bob-heavy-water-electrolysis"].energy_required = 2
+    if data.raw.recipe["sodium-chlorate"] then
+      data.raw.recipe["sodium-chlorate"].energy_required = 6
+      data.raw.recipe["sodium-perchlorate"].energy_required = 2
+    end
   end
   data.raw["assembling-machine"]["bob-electrolyser"].energy_usage = "1050kW"
   data.raw["assembling-machine"]["bob-electrolyser"].energy_source.drain = "12kW"
+  data.raw.recipe["bob-water-electrolysis"].allow_consumption = false
+  data.raw.recipe["bob-salt-water-electrolysis"].allow_consumption = false
+  data.raw.recipe["bob-heavy-water-electrolysis"].allow_consumption = false
+  if data.raw.recipe["sodium-chlorate"] then
+    data.raw.recipe["sodium-chlorate"].allow_consumption = false
+    data.raw.recipe["sodium-perchlorate"].allow_consumption = false
+  end
+  if data.raw.recipe["brine-electrolysis"] then
+    data.raw.recipe["brine-electrolysis"].allow_consumption = false
+  end
 end
 
 --change icons.

--- a/bobrevamp/data-updates.lua
+++ b/bobrevamp/data-updates.lua
@@ -297,8 +297,6 @@ if feature_flags["quality"] then
   if data.raw.recipe["sodium-chlorate"] then
     bobmods.lib.recipe.update_recycling_recipe_to_self_recipe("sodium-chlorate", false)
     bobmods.lib.recipe.update_recycling_recipe_to_self_recipe("sodium-perchlorate", false)
-    data.raw.recipe["sodium-chlorate"].energy_required = 6
-    data.raw.recipe["sodium-perchlorate"].energy_required = 2
   end
 
   bobmods.lib.recipe.update_recycling_recipe({


### PR DESCRIPTION
Revises hydrogen electrolysis recipes to not allow efficiency modules, in order to finish closing the hydrogen exploit. I had though that this would require a new function to disallow only one module category, but it turns out you can just use allow_consumption = false instead. Apparently, those "allow" parameters only work in one direction. allow_consumption = false blocks any module that decreases energy usage, rather than any module that affects consumption at all, while allow_speed = false blocks modules that increase speed, but not those that decrease it.