### PR TITLE
Fix thorium glow

### DIFF
--- a/boblibrary/ore-functions.lua
+++ b/boblibrary/ore-functions.lua
@@ -242,7 +242,7 @@ function bobmods.lib.resource.effect(inputs)
     frame_count = frame_count,
     variation_count = variation_count,
     tint = inputs.tint,
-    scale = inputs.scale,
+    scale = scale,
     blend_mode = "additive",
     flags = { "light" },
   }


### PR DESCRIPTION
Fixes a small issue with thorium ore, where its glow seemed to be much too bright. It turned out the actual issue was that the wrong scale was being used on the glow effect layer, so it was twice as big as it should have been, causing overlap.