### PR TITLE
Drawing box fixes

### DIFF
--- a/bobassembly/prototypes/assembly-updates.lua
+++ b/bobassembly/prototypes/assembly-updates.lua
@@ -49,6 +49,7 @@ end
 
 data.raw["assembling-machine"]["assembling-machine-3"].module_slots = 3
 data.raw["assembling-machine"]["assembling-machine-3"].next_upgrade = "assembling-machine-4"
+data.raw["assembling-machine"]["assembling-machine-3"].drawing_box_vertical_extension = nil
 
 if data.raw.item["bob-aluminium-plate"] then
   bobmods.lib.recipe.replace_ingredient("assembling-machine-4", "steel-plate", "bob-aluminium-plate")

--- a/bobassembly/prototypes/chemical-plant.lua
+++ b/bobassembly/prototypes/chemical-plant.lua
@@ -11,6 +11,7 @@ if settings.startup["bobmods-assembly-chemicalplants"].value == true then
   data.raw["assembling-machine"]["chemical-plant"].fast_replaceable_group = "chemical-plant"
   data.raw["assembling-machine"]["chemical-plant"].order = "e[chemical-plant-1]"
   data.raw["assembling-machine"]["chemical-plant"].energy_usage = "160kW"
+  data.raw["assembling-machine"]["chemical-plant"].drawing_box_vertical_extension = 0.6
 
   data.raw.item["chemical-plant"].stack_size = 50
   data.raw.item["chemical-plant"].subgroup = "bob-chemical-machine"
@@ -231,6 +232,7 @@ if settings.startup["bobmods-assembly-chemicalplants"].value == true then
       dying_explosion = "medium-explosion",
       collision_box = { { -1.2, -1.2 }, { 1.2, 1.2 } },
       selection_box = { { -1.5, -1.5 }, { 1.5, 1.5 } },
+      drawing_box_vertical_extension = 0.6,
       allowed_effects = { "consumption", "speed", "productivity", "pollution" },
       module_slots = 4,
       icon_draw_specification = {
@@ -270,6 +272,7 @@ if settings.startup["bobmods-assembly-chemicalplants"].value == true then
       dying_explosion = "medium-explosion",
       collision_box = { { -1.2, -1.2 }, { 1.2, 1.2 } },
       selection_box = { { -1.5, -1.5 }, { 1.5, 1.5 } },
+      drawing_box_vertical_extension = 0.6,
       allowed_effects = { "consumption", "speed", "productivity", "pollution" },
       module_slots = 5,
       icons_positioning = {
@@ -317,6 +320,7 @@ if settings.startup["bobmods-assembly-chemicalplants"].value == true then
       dying_explosion = "medium-explosion",
       collision_box = { { -1.2, -1.2 }, { 1.2, 1.2 } },
       selection_box = { { -1.5, -1.5 }, { 1.5, 1.5 } },
+      drawing_box_vertical_extension = 0.6,
       allowed_effects = { "consumption", "speed", "productivity", "pollution" },
       module_slots = 6,
       icons_positioning = {

--- a/boblogistics/prototypes/entity/roboport.lua
+++ b/boblogistics/prototypes/entity/roboport.lua
@@ -788,6 +788,7 @@ data:extend({
     corpse = "small-remnants",
     collision_box = { { -0.7, -0.7 }, { 0.7, 0.7 } },
     selection_box = { { -1, -1 }, { 1, 1 } },
+    drawing_box_vertical_extension = 1.4,
     dying_explosion = "medium-explosion",
     energy_source = {
       type = "electric",
@@ -856,17 +857,6 @@ data:extend({
       sound = { filename = "__base__/sound/roboport-working.ogg", volume = 0.4 },
       max_sounds_per_prototype = 3,
     },
-    factoriopedia_simulation = {
-      init = [[
-        game.simulation.camera_position = {0, -1}
-        game.simulation.camera_zoom = 2.0
-        game.surfaces[1].create_entities_from_blueprint_string
-        {
-          string = "0eNqNj9EOgjAMRf+lzyMRAZX9ijGEYSVNRofbMCDZv7tBoq++tc3tOe0KSk84WmIPcgXqDDuQ1xUc9dzqNON2QJCgjMq06cl56rK3YcxwHlu+o4UggGIxg8zDTQCyJ0+4c7ZmaXgaVEzKXPzBEzAaFxGGkz9is1LAAvIQRRafEzrfPEh7tC4FHHYpu/t+h4R0C3kckuz7pIBXXNvQ1elYl3VdVcXlXNRFCB+52Fwa",
-          position = {0, 0}
-        }
-      ]],
-    },
   },
 
   {
@@ -881,6 +871,7 @@ data:extend({
     corpse = "small-remnants",
     collision_box = { { -0.7, -0.7 }, { 0.7, 0.7 } },
     selection_box = { { -1, -1 }, { 1, 1 } },
+    drawing_box_vertical_extension = 1.4,
     dying_explosion = "medium-explosion",
     energy_source = {
       type = "electric",
@@ -949,17 +940,6 @@ data:extend({
       sound = { filename = "__base__/sound/roboport-working.ogg", volume = 0.4 },
       max_sounds_per_prototype = 3,
     },
-    factoriopedia_simulation = {
-      init = [[
-        game.simulation.camera_position = {0, -1}
-        game.simulation.camera_zoom = 2.0
-        game.surfaces[1].create_entities_from_blueprint_string
-        {
-          string = "0eNqNj9EOgjAMRf+lzyNREIX9ijGEYSVNRofbMCDZv7tBoq++tc3tufeuoPSEoyX2IFegzrADeV3BUc+tTjduBwQJyqhMm56cpy57G8YM57HlO9oshyCA4jiDPIabAGRPnnAnbcvS8DQotFEg/iIKGI2LEMMpQwJXAhaQh2hl8Tmh882DtEfrksBhl7S74y9KSGnI45DsvkUFvOLbhi7PeX2q67IsqktRFyF8ANEdXOA=",
-          position = {0, 0}
-        }
-      ]],
-    },
   },
 
   {
@@ -974,6 +954,7 @@ data:extend({
     corpse = "small-remnants",
     collision_box = { { -0.7, -0.7 }, { 0.7, 0.7 } },
     selection_box = { { -1, -1 }, { 1, 1 } },
+    drawing_box_vertical_extension = 1.4,
     dying_explosion = "medium-explosion",
     energy_source = {
       type = "electric",
@@ -1042,17 +1023,6 @@ data:extend({
       sound = { filename = "__base__/sound/roboport-working.ogg", volume = 0.4 },
       max_sounds_per_prototype = 3,
     },
-    factoriopedia_simulation = {
-      init = [[
-        game.simulation.camera_position = {0, -1}
-        game.simulation.camera_zoom = 2.0
-        game.surfaces[1].create_entities_from_blueprint_string
-        {
-          string = "0eNqNj9EOgjAMRf+lzyNRJwr7FWMIw2qajA63YUCyf3eDRF99a5vbc+9dQJsRB0ccQC1AnWUP6rKApwe3Jt+47REUaKsLYx/kA3XF2zIWOA0t39AVEqIASuMEah+vApADBcKNtC5zw2Ov0SWB+IsoYLA+QSznDAksKwEzqF2ycvgc0YfmTiag81ngscvazfEXJeY0FLDPdt+iAl7pbUWXp0N9rOuylNVZ1jLGD9MxXOQ=",
-          position = {0, 0}
-        }
-      ]],
-    },
   },
 
   {
@@ -1067,6 +1037,7 @@ data:extend({
     corpse = "small-remnants",
     collision_box = { { -0.7, -0.7 }, { 0.7, 0.7 } },
     selection_box = { { -1, -1 }, { 1, 1 } },
+    drawing_box_vertical_extension = 1.4,
     dying_explosion = "medium-explosion",
     energy_source = {
       type = "electric",
@@ -1134,17 +1105,6 @@ data:extend({
     working_sound = {
       sound = { filename = "__base__/sound/roboport-working.ogg", volume = 0.4 },
       max_sounds_per_prototype = 3,
-    },
-    factoriopedia_simulation = {
-      init = [[
-        game.simulation.camera_position = {0, -1}
-        game.simulation.camera_zoom = 2.0
-        game.surfaces[1].create_entities_from_blueprint_string
-        {
-          string = "0eNqNj8EOgjAQRP9lz+0BAbX9FWMI4Go2KVtsiwFJ/90WEr16293MvplZoTMTjo44gF6Besse9GUFTw9uTb5xOyBo6GwnjX2QD9TLt2WUOI8t39DJCqIASuMMuohXAciBAuFO2pal4Wno0CWB+IsoYLQ+QSznDAlcVwIW0LJIXg6fE/rQ3MkEdD4rPPZZvFv+ssQchwIO2e/bVMArvW3s+nhQlVJ1XZ5PpSpj/AAh410S",
-          position = {0, 0}
-        }
-      ]],
     },
   },
 })

--- a/bobpower/prototypes/burner-generator.lua
+++ b/bobpower/prototypes/burner-generator.lua
@@ -58,6 +58,7 @@ if settings.startup["bobmods-power-burnergenerator"].value == true then
       fast_replaceable_group = "burner-generator",
       collision_box = { { -1.35, -1.35 }, { 1.35, 1.35 } },
       selection_box = { { -1.5, -1.5 }, { 1.5, 1.5 } },
+      drawing_box_vertical_extension = 0.8,
       energy_source = {
         type = "electric",
         usage_priority = "secondary-output",

--- a/bobtech/prototypes/entity/entity.lua
+++ b/bobtech/prototypes/entity/entity.lua
@@ -318,6 +318,7 @@ if settings.startup["bobmods-burnerphase"].value == true then
         fast_replaceable_group = "burner-generator",
         collision_box = { { -1.35, -1.35 }, { 1.35, 1.35 } },
         selection_box = { { -1.5, -1.5 }, { 1.5, 1.5 } },
+        drawing_box_vertical_extension = 0.8,
         energy_source = {
           type = "electric",
           usage_priority = "secondary-output",

--- a/bobwarfare/prototypes/entity/tank.lua
+++ b/bobwarfare/prototypes/entity/tank.lua
@@ -312,6 +312,7 @@ data:extend({
     impact_category = "metal-large",
     collision_box = { { -0.9, -1.3 }, { 0.9, 1.3 } },
     selection_box = { { -0.9, -1.3 }, { 0.9, 1.3 } },
+    drawing_box_vertical_extension = 0.5,
     effectivity = 0.95,
     braking_power = "1000kW",
     energy_source = {
@@ -497,6 +498,7 @@ data:extend({
     impact_category = "metal-large",
     collision_box = { { -0.9, -1.3 }, { 0.9, 1.3 } },
     selection_box = { { -0.9, -1.3 }, { 0.9, 1.3 } },
+    drawing_box_vertical_extension = 0.5,
     effectivity = 1,
     braking_power = "1200kW",
     energy_source = {

--- a/bobwarfare/prototypes/entity/turrets.lua
+++ b/bobwarfare/prototypes/entity/turrets.lua
@@ -3,6 +3,7 @@ local warefareSounds = require("prototypes.entity.sounds")
 
 data.raw["ammo-turret"]["gun-turret"].fast_replaceable_group = "turret"
 data.raw["electric-turret"]["laser-turret"].fast_replaceable_group = "turret"
+data.raw["electric-turret"]["laser-turret"].drawing_box_vertical_extension = 0.7
 
 local black = { r = 0, g = 0, b = 0, a = 1 }
 local magenta = { r = 1, g = 0, b = 1, a = 1 }
@@ -549,7 +550,7 @@ local function bob_laser_turret(inputs)
     corpse = "laser-turret-remnants",
     collision_box = { { -0.7 * size, -0.7 * size }, { 0.7 * size, 0.7 * size } },
     selection_box = { { -1 * size, -1 * size }, { 1 * size, 1 * size } },
-    drawing_box_vertical_extension = 0.3 * size,
+    drawing_box_vertical_extension = 0.7 * size,
     circuit_wire_max_distance = default_circuit_wire_max_distance,
     dying_explosion = "medium-explosion",
     rotation_speed = inputs.rotation_speed or 0.01,


### PR DESCRIPTION
Fixes a few right hand info bar/factoriopedia display issues. I went through all of the vanilla prototypes that use drawing_box_vertical_extension in order to identify potential issues, but there were only a couple. Including:

Burner generator(both Power and Tech versions) and chemical plants as noted in #302 
Laser turrets(had to be adjusted quite a bit due to plasma turrets always standing up)
Tanks
Removed drawing_box_vertical_extension from assembling machine 3, since it isn't needed and the others don't have it
Edit: Applied the change to logistic zone expanders as well, and removed their factoriopedia_simulation