### PR TITLE
AAI vehicles adjustments

### DIFF
--- a/bobwarfare/data-final-fixes.lua
+++ b/bobwarfare/data-final-fixes.lua
@@ -1,0 +1,108 @@
+if mods["aai-programmable-vehicles"] then
+  --Restore new spidertron armaments
+  data.raw["spider-vehicle"].tankotron.guns = { "spidertron-cannon-1", "spidertron-cannon-2", }
+  data.raw["spider-vehicle"]["heavy-spidertron"].guns = { 
+    "spidertron-rocket-launcher-1",
+    "spidertron-rocket-launcher-2",
+    "spidertron-rocket-launcher-3",
+    "spidertron-rocket-launcher-4",
+    "spidertron-rocket-launcher-1",
+    "spidertron-rocket-launcher-2",
+    "spidertron-rocket-launcher-3",
+    "spidertron-rocket-launcher-4",
+  }
+  if mods["aai-vehicles-chaingunner"] then
+    --Restore machine gun to tank 1, since the chaingunner alone is far too fragile to survive midgame enemies
+    if mods["aai-vehicles-flame-tank"] then
+      data.raw.car.tank.guns = { "tank-cannon", "tank-machine-gun" }
+      aai_make_ai_vehicles(data.raw.car.tank)
+      data.raw.technology.tank.effects = {
+        {
+          recipe = "tank",
+          type = "unlock-recipe"
+        },
+        {
+          recipe = "cannon-shell",
+          type = "unlock-recipe"
+        },
+        {
+          recipe = "explosive-cannon-shell",
+          type = "unlock-recipe"
+        },
+        {
+          recipe = "cannon-shell-precision",
+          type = "unlock-recipe"
+        },
+        {
+          recipe = "explosive-cannon-shell-precision",
+          type = "unlock-recipe"
+        },
+        {
+          recipe = "tank-tank-cannon",
+          type = "unlock-recipe"
+        },
+        {
+          recipe = "tank-tank-cannon-reverse",
+          type = "unlock-recipe"
+        },
+        {
+          recipe = "tank-tank-machine-gun",
+          type = "unlock-recipe"
+        },
+        {
+          recipe = "tank-tank-machine-gun-reverse",
+          type = "unlock-recipe"
+        },
+      }
+    else
+      data.raw.car.tank.guns = { "tank-cannon", "tank-machine-gun", "tank-flamethrower" }
+      aai_make_ai_vehicles(data.raw.car.tank)
+      data.raw.technology.tank.effects = {
+        {
+          recipe = "tank",
+          type = "unlock-recipe"
+        },
+        {
+          recipe = "cannon-shell",
+          type = "unlock-recipe"
+        },
+        {
+          recipe = "explosive-cannon-shell",
+          type = "unlock-recipe"
+        },
+        {
+          recipe = "cannon-shell-precision",
+          type = "unlock-recipe"
+        },
+        {
+          recipe = "explosive-cannon-shell-precision",
+          type = "unlock-recipe"
+        },
+        {
+          recipe = "tank-tank-cannon",
+          type = "unlock-recipe"
+        },
+        {
+          recipe = "tank-tank-cannon-reverse",
+          type = "unlock-recipe"
+        },
+        {
+          recipe = "tank-tank-machine-gun",
+          type = "unlock-recipe"
+        },
+        {
+          recipe = "tank-tank-machine-gun-reverse",
+          type = "unlock-recipe"
+        },
+        {
+          recipe = "tank-tank-flamethrower",
+          type = "unlock-recipe"
+        },
+        {
+          recipe = "tank-tank-flamethrower-reverse",
+          type = "unlock-recipe"
+        },
+      }
+    end
+  end
+end

--- a/bobwarfare/prototypes/entity/tank.lua
+++ b/bobwarfare/prototypes/entity/tank.lua
@@ -301,7 +301,7 @@ data:extend({
       },
       {
         type = "bob-pierce",
-        percent = 20,
+        percent = 15,
       },
       {
         type = "plasma",
@@ -487,7 +487,7 @@ data:extend({
       },
       {
         type = "bob-pierce",
-        percent = 40,
+        percent = 30,
       },
       {
         type = "plasma",

--- a/bobwarfare/prototypes/entity/tank.lua
+++ b/bobwarfare/prototypes/entity/tank.lua
@@ -491,6 +491,7 @@ data:extend({
       },
       {
         type = "plasma",
+        decrease = 35,
         percent = 90,
       },
     },

--- a/bobwarfare/prototypes/overides.lua
+++ b/bobwarfare/prototypes/overides.lua
@@ -37,3 +37,507 @@ data.raw.projectile["cannon-projectile"].force_condition = "not-same"
 data.raw.projectile["explosive-cannon-projectile"].force_condition = "not-same"
 data.raw.projectile["uranium-cannon-projectile"].force_condition = "not-same"
 data.raw.projectile["explosive-uranium-cannon-projectile"].force_condition = "not-same"
+
+--Update AAI vehicle resistances to be comparable to Warfare's vehicles, restore machine gun to tank
+if data.raw.car["vehicle-hauler"] then
+  data.raw.car["vehicle-hauler"].resistances = {
+    {
+      type = "fire",
+      decrease = 5,
+      percent = 40,
+    },
+    {
+      type = "physical",
+      percent = 25,
+    },
+    {
+      type = "impact",
+      decrease = 50,
+      percent = 60,
+    },
+    {
+      type = "acid",
+      percent = 25,
+    },
+    {
+      type = "plasma",
+      decrease = 15,
+      percent = 50,
+    },
+  }
+end
+if data.raw.car["vehicle-chaingunner"] then
+  data.raw.car["vehicle-chaingunner"].resistances = {
+    {
+      type = "fire",
+      percent = 50,
+    },
+    {
+      type = "physical",
+      decrease = 5,
+      percent = 25,
+    },
+    {
+      type = "impact",
+      decrease = 40,
+      percent = 40,
+    },
+    {
+      type = "acid",
+      percent = 25,
+    },
+    {
+      type = "plasma",
+      decrease = 15,
+      percent = 50,
+    },
+  }
+end
+if data.raw.car["vehicle-warden"] then
+  data.raw.car["vehicle-warden"].resistances = {
+    {
+      type = "fire",
+      decrease = 5,
+      percent = 40,
+    },
+    {
+      type = "poison",
+      decrease = 5,
+      percent = 50,
+    },
+    {
+      type = "physical",
+      decrease = 5,
+      percent = 30,
+    },
+    {
+      type = "impact",
+      decrease = 50,
+      percent = 50,
+    },
+    {
+      type = "explosion",
+      decrease = 10,
+      percent = 30,
+    },
+    {
+      type = "acid",
+      decrease = 5,
+      percent = 60,
+    },
+    {
+      type = "electric",
+      percent = 20,
+    },
+    {
+      type = "laser",
+      percent = 40,
+    },
+    {
+      type = "plasma",
+      decrease = 15,
+      percent = 50,
+    },
+  }
+end
+if data.raw.car["vehicle-laser-tank"] then
+  data.raw.car["vehicle-laser-tank"].resistances = {
+    {
+      type = "fire",
+      decrease = 5,
+      percent = 40,
+    },
+    {
+      type = "poison",
+      decrease = 5,
+      percent = 50,
+    },
+    {
+      type = "physical",
+      decrease = 15,
+      percent = 45,
+    },
+    {
+      type = "impact",
+      decrease = 50,
+      percent = 70,
+    },
+    {
+      type = "explosion",
+      decrease = 20,
+      percent = 60,
+    },
+    {
+      type = "acid",
+      decrease = 5,
+      percent = 60,
+    },
+    {
+      type = "electric",
+      decrease = 7,
+      percent = 25,
+    },
+    {
+      type = "laser",
+      percent = 20,
+    },
+    {
+      type = "plasma",
+      decrease = 15,
+      percent = 50,
+    },
+  }
+end
+if data.raw.car["vehicle-flame-tank"] then
+  data.raw.car["vehicle-flame-tank"].resistances = {
+    {
+      type = "fire",
+      percent = 100,
+    },
+    {
+      type = "poison",
+      decrease = 5,
+      percent = 50,
+    },
+    {
+      type = "physical",
+      decrease = 15,
+      percent = 45,
+    },
+    {
+      type = "impact",
+      decrease = 50,
+      percent = 70,
+    },
+    {
+      type = "explosion",
+      decrease = 20,
+      percent = 60,
+    },
+    {
+      type = "acid",
+      decrease = 5,
+      percent = 60,
+    },
+    {
+      type = "electric",
+      decrease = 10,
+      percent = 30,
+    },
+    {
+      type = "laser",
+      percent = 20,
+    },
+    {
+      type = "plasma",
+      decrease = 15,
+      percent = 50,
+    },
+  }
+end
+if data.raw.car["vehicle-flame-tumbler"] then
+  data.raw.car["vehicle-flame-tumbler"].resistances = {
+    {
+      type = "fire",
+      decrease = 30,
+      percent = 99,
+    },
+    {
+      type = "poison",
+      decrease = 3,
+      percent = 40,
+    },
+    {
+      type = "physical",
+      decrease = 5,
+      percent = 25,
+    },
+    {
+      type = "impact",
+      decrease = 50,
+      percent = 90,
+    },
+    {
+      type = "explosion",
+      decrease = 10,
+      percent = 30,
+    },
+    {
+      type = "acid",
+      decrease = 5,
+      percent = 35,
+    },
+    {
+      type = "electric",
+      percent = 20,
+    },
+    {
+      type = "plasma",
+      decrease = 15,
+      percent = 50,
+    },
+  }
+end
+if data.raw.car.ironclad then
+  data.raw.car.ironclad.resistances = {
+    {
+      type = "fire",
+      decrease = 12,
+      percent = 60,
+    },
+    {
+      type = "physical",
+      decrease = 15,
+      percent = 60,
+    },
+    {
+      type = "impact",
+      decrease = 50,
+      percent = 80,
+    },
+    {
+      type = "explosion",
+      decrease = 20,
+      percent = 70,
+    },
+    {
+      type = "acid",
+      decrease = 15,
+      percent = 50,
+    },
+    {
+      type = "electric",
+      decrease = 15,
+      percent = 50,
+    },
+    {
+      type = "plasma",
+      decrease = 15,
+      percent = 50,
+    },
+  }
+end
+if data.raw.car["vehicle-miner-mk5"] then
+  data.raw.car["vehicle-miner"].resistances = {
+    {
+      type = "fire",
+      decrease = 5,
+      percent = 40,
+    },
+    {
+      type = "poison",
+      decrease = 4,
+      percent = 40,
+    },
+    {
+      type = "physical",
+      decrease = 3,
+      percent = 20,
+    },
+    {
+      type = "impact",
+      decrease = 50,
+      percent = 60,
+    },
+    {
+      type = "acid",
+      decrease = 4,
+      percent = 40,
+    },
+    {
+      type = "electric",
+      decrease = 5,
+      percent = 40,
+    },
+    {
+      type = "plasma",
+      decrease = 15,
+      percent = 50,
+    },
+  }
+  data.raw.car["vehicle-miner-mk2"].resistances = {
+    {
+      type = "fire",
+      decrease = 7,
+      percent = 50,
+    },
+    {
+      type = "poison",
+      decrease = 6,
+      percent = 50,
+    },
+    {
+      type = "physical",
+      decrease = 7,
+      percent = 30,
+    },
+    {
+      type = "impact",
+      decrease = 50,
+      percent = 60,
+    },
+    {
+      type = "explosion",
+      percent = 20,
+    },
+    {
+      type = "acid",
+      decrease = 6,
+      percent = 50,
+    },
+    {
+      type = "electric",
+      decrease = 7,
+      percent = 50,
+    },
+    {
+      type = "laser",
+      percent = 20,
+    },
+    {
+      type = "plasma",
+      decrease = 15,
+      percent = 50,
+    },
+  }
+  data.raw.car["vehicle-miner-mk3"].resistances = {
+    {
+      type = "fire",
+      decrease = 10,
+      percent = 60,
+    },
+    {
+      type = "poison",
+      decrease = 8,
+      percent = 60,
+    },
+    {
+      type = "physical",
+      decrease = 12,
+      percent = 40,
+    },
+    {
+      type = "impact",
+      decrease = 50,
+      percent = 60,
+    },
+    {
+      type = "explosion",
+      percent = 30,
+    },
+    {
+      type = "acid",
+      decrease = 8,
+      percent = 60,
+    },
+    {
+      type = "electric",
+      decrease = 10,
+      percent = 60,
+    },
+    {
+      type = "laser",
+      percent = 30,
+    },
+    {
+      type = "plasma",
+      decrease = 15,
+      percent = 50,
+    },
+  }
+  data.raw.car["vehicle-miner-mk4"].resistances = {
+    {
+      type = "fire",
+      decrease = 15,
+      percent = 70,
+    },
+    {
+      type = "poison",
+      decrease = 10,
+      percent = 70,
+    },
+    {
+      type = "physical",
+      decrease = 18,
+      percent = 50,
+    },
+    {
+      type = "impact",
+      decrease = 50,
+      percent = 60,
+    },
+    {
+      type = "explosion",
+      percent = 40,
+    },
+    {
+      type = "acid",
+      decrease = 10,
+      percent = 70,
+    },
+    {
+      type = "electric",
+      decrease = 15,
+      percent = 70,
+    },
+    {
+      type = "laser",
+      percent = 40,
+    },
+    {
+      type = "plasma",
+      decrease = 15,
+      percent = 50,
+    },
+  }
+  data.raw.car["vehicle-miner-mk5"].resistances = {
+    {
+      type = "fire",
+      decrease = 20,
+      percent = 80,
+    },
+    {
+      type = "poison",
+      decrease = 12,
+      percent = 80,
+    },
+    {
+      type = "physical",
+      decrease = 25,
+      percent = 60,
+    },
+    {
+      type = "impact",
+      decrease = 50,
+      percent = 60,
+    },
+    {
+      type = "explosion",
+      percent = 60,
+    },
+    {
+      type = "acid",
+      decrease = 12,
+      percent = 80,
+    },
+    {
+      type = "electric",
+      decrease = 20,
+      percent = 80,
+    },
+    {
+      type = "laser",
+      percent = 60,
+    },
+    {
+      type = "plasma",
+      decrease = 15,
+      percent = 50,
+    },
+  }
+end
+if mods["aai-programmable-vehicles"] then
+  --Temporarily change new spidertrons to only have one gun so that they don't generate an excessive number of essentially identical AI versions. Proper armaments will be restored in data-final-fixes.
+  data.raw["spider-vehicle"].tankotron.guns = { "spidertron-cannon-1", }
+  data.raw["spider-vehicle"]["heavy-spidertron"].guns = { "spidertron-rocket-launcher-1", }
+end


### PR DESCRIPTION
Adds resistance adjustments to AAI vehicles to bring them in line with other vehicle resistances.
Removes and then adds back all but one gun from the tanktron and heavy spidertron so that when AAI Programmable Vehicles generates the AI versions there's only one of each instead of multiple redundant copies.
Since the combination of AAI Chaingunner+AAI PV removes the machine gun from tanks, and the chaingunner isn't nearly good enough to stand up to midgame enemies, this readds the the tank's machine gun and redoes the AI vehicle generation so that both versions are available.
Also makes a few adjustments to tank 2 and tank 3 resistances.