### PR TITLE
New circuit connectors

### DIFF
--- a/bobassembly/data.lua
+++ b/bobassembly/data.lua
@@ -5,6 +5,28 @@ if not bobmods.assembly then
   bobmods.assembly = {}
 end
 
+circuit_connector_definitions["bob-steel-furnace"] = circuit_connector_definitions.create_vector
+(
+  universal_connector_template,
+  {
+    { variation = 17, main_offset = util.by_pixel(14, -6), shadow_offset = util.by_pixel(20.5, 20), show_shadow = true },
+    { variation = 17, main_offset = util.by_pixel(14, -6), shadow_offset = util.by_pixel(20.5, 20), show_shadow = true },
+    { variation = 17, main_offset = util.by_pixel(14, -6), shadow_offset = util.by_pixel(20.5, 20), show_shadow = true },
+    { variation = 17, main_offset = util.by_pixel(14, -6), shadow_offset = util.by_pixel(20.5, 20), show_shadow = true }
+  }
+)
+
+circuit_connector_definitions["bob-electric-furnace"] = circuit_connector_definitions.create_vector
+(
+  universal_connector_template,
+  {
+    { variation = 0, main_offset = util.by_pixel(7, 2), shadow_offset = util.by_pixel(25.5, 30), show_shadow = false },
+    { variation = 0, main_offset = util.by_pixel(7, 2), shadow_offset = util.by_pixel(25.5, 30), show_shadow = false },
+    { variation = 0, main_offset = util.by_pixel(7, 2), shadow_offset = util.by_pixel(25.5, 30), show_shadow = false },
+    { variation = 0, main_offset = util.by_pixel(7, 2), shadow_offset = util.by_pixel(25.5, 30), show_shadow = false }
+  }
+)
+
 require("prototypes.assembly")
 require("prototypes.assembly-electronics")
 require("prototypes.assembly-burner")

--- a/bobassembly/prototypes/chemical-mixing-furnace.lua
+++ b/bobassembly/prototypes/chemical-mixing-furnace.lua
@@ -36,34 +36,6 @@ then
     }
   end
 
-  circuit_connector_definitions["electric-furnace"] =
-    circuit_connector_definitions.create_vector(universal_connector_template, {
-      {
-        variation = 18,
-        main_offset = util.by_pixel(28, 25),
-        shadow_offset = util.by_pixel(39, 31),
-        show_shadow = true,
-      },
-      {
-        variation = 18,
-        main_offset = util.by_pixel(28, 25),
-        shadow_offset = util.by_pixel(39, 31),
-        show_shadow = true,
-      },
-      {
-        variation = 18,
-        main_offset = util.by_pixel(28, 25),
-        shadow_offset = util.by_pixel(39, 31),
-        show_shadow = true,
-      },
-      {
-        variation = 18,
-        main_offset = util.by_pixel(28, 25),
-        shadow_offset = util.by_pixel(39, 31),
-        show_shadow = true,
-      },
-    })
-
   data:extend({
     {
       type = "item",
@@ -151,7 +123,7 @@ then
       minable = { mining_time = 1, result = "bob-electric-chemical-mixing-furnace" },
       max_health = 450,
       circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
-      circuit_connector = circuit_connector_definitions["electric-furnace"],
+      circuit_connector = circuit_connector_definitions["bob-electric-chemical-furnace"],
       corpse = "big-remnants",
       resistances = {
         {
@@ -222,7 +194,7 @@ then
       minable = { mining_time = 1, result = "bob-electric-chemical-mixing-furnace-2" },
       max_health = 550,
       circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
-      circuit_connector = circuit_connector_definitions["electric-furnace"],
+      circuit_connector = circuit_connector_definitions["bob-electric-chemical-furnace"],
       corpse = "big-remnants",
       resistances = {
         {

--- a/bobassembly/prototypes/electric-furnace.lua
+++ b/bobassembly/prototypes/electric-furnace.lua
@@ -85,6 +85,8 @@ if settings.startup["bobmods-assembly-furnaces"].value == true and data.raw.furn
       flags = { "placeable-neutral", "placeable-player", "player-creation" },
       minable = { mining_time = 1, result = input.name },
       max_health = input.max_health or 150,
+      circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
+      circuit_connector = circuit_connector_definitions["bob-electric-furnace"],
       corpse = "big-remnants",
       dying_explosion = "medium-explosion",
       resistances = {
@@ -141,6 +143,7 @@ if settings.startup["bobmods-assembly-furnaces"].value == true and data.raw.furn
   end
 
   data.raw.item["electric-furnace"].order = "c[electric-furnace-1]"
+  data.raw.furnace["electric-furnace"].circuit_connector = circuit_connector_definitions["bob-electric-furnace"]
 
   data:extend({
     {

--- a/bobassembly/prototypes/fluid-furnace.lua
+++ b/bobassembly/prototypes/fluid-furnace.lua
@@ -103,6 +103,7 @@ if settings.startup["bobmods-assembly-oilfurnaces"].value == true then
     },
   })
   data.raw.furnace["bob-fluid-furnace"].energy_source = fluid_energy_source()
+  data.raw.furnace["bob-fluid-furnace"].circuit_connector = circuit_connector_definitions["bob-steel-furnace"]
 
   if
     settings.startup["bobmods-plates-convert-recipes"]
@@ -228,6 +229,7 @@ if settings.startup["bobmods-assembly-oilfurnaces"].value == true then
     })
 
     data.raw["assembling-machine"]["bob-fluid-mixing-furnace"].energy_source = fluid_energy_source()
+    data.raw["assembling-machine"]["bob-fluid-mixing-furnace"].circuit_connector = circuit_connector_definitions["bob-steel-furnace"]
 
     if
       settings.startup["bobmods-plates-convert-recipes"]
@@ -402,6 +404,7 @@ if settings.startup["bobmods-assembly-oilfurnaces"].value == true then
     end
 
     data.raw["assembling-machine"]["bob-fluid-chemical-furnace"].energy_source = fluid_energy_source()
+    data.raw["assembling-machine"]["bob-fluid-chemical-furnace"].circuit_connector = circuit_connector_definitions["bob-steel-furnace"]
 
     if
       settings.startup["bobmods-plates-convert-recipes"]

--- a/bobplates/prototypes/distillery.lua
+++ b/bobplates/prototypes/distillery.lua
@@ -366,6 +366,21 @@ function bobmods.plates.distillery_working_visualisations_flipped(speed)
   }
 end
 
+circuit_connector_definitions["bob-distillery"] =
+  circuit_connector_definitions.create_vector(universal_connector_template, {
+    { variation = 0, main_offset = util.by_pixel(21, 14), shadow_offset = util.by_pixel(9, 9), show_shadow = false },
+    { variation = 6, main_offset = util.by_pixel(-24, 15), shadow_offset = util.by_pixel(0, 0), show_shadow = false },
+    { variation = 0, main_offset = util.by_pixel(-11, 14), shadow_offset = util.by_pixel(9, 9), show_shadow = false },
+    { variation = 6, main_offset = util.by_pixel(-24, -17.5), shadow_offset = util.by_pixel(0, 0), show_shadow = false },
+  })
+circuit_connector_definitions["bob-distillery-flipped"] =
+  circuit_connector_definitions.create_vector(universal_connector_template, {
+    { variation = 0, main_offset = util.by_pixel(-11, 14), shadow_offset = util.by_pixel(9, 9), show_shadow = false },
+    { variation = 6, main_offset = util.by_pixel(-24, -17.5), shadow_offset = util.by_pixel(0, 0), show_shadow = false },
+    { variation = 0, main_offset = util.by_pixel(21, 14), shadow_offset = util.by_pixel(9, 9), show_shadow = false },
+    { variation = 6, main_offset = util.by_pixel(-24, 15), shadow_offset = util.by_pixel(0, 0), show_shadow = false },
+  })
+
 if settings.startup["bobmods-plates-purewater"].value == true then
   data:extend({
     {
@@ -411,6 +426,9 @@ if settings.startup["bobmods-plates-purewater"].value == true then
       flags = { "placeable-neutral", "placeable-player", "player-creation" },
       minable = { mining_time = 0.2, result = "bob-distillery" },
       max_health = 200,
+      circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
+      circuit_connector = circuit_connector_definitions["bob-distillery"],
+      circuit_connector_flipped = circuit_connector_definitions["bob-distillery-flipped"],
       corpse = "medium-remnants",
       collision_box = { { -0.7, -0.7 }, { 0.7, 0.7 } },
       selection_box = { { -0.9, -0.9 }, { 0.9, 0.9 } },

--- a/bobplates/prototypes/entity/entities.lua
+++ b/bobplates/prototypes/entity/entities.lua
@@ -85,13 +85,63 @@ circuit_connector_definitions["bob-electrolyser"] =
     },
   })
 
-circuit_connector_definitions["electric-furnace"] =
-  circuit_connector_definitions.create_vector(universal_connector_template, {
-    { variation = 18, main_offset = util.by_pixel(28, 25), shadow_offset = util.by_pixel(39, 31), show_shadow = true },
-    { variation = 18, main_offset = util.by_pixel(28, 25), shadow_offset = util.by_pixel(39, 31), show_shadow = true },
-    { variation = 18, main_offset = util.by_pixel(28, 25), shadow_offset = util.by_pixel(39, 31), show_shadow = true },
-    { variation = 18, main_offset = util.by_pixel(28, 25), shadow_offset = util.by_pixel(39, 31), show_shadow = true },
-  })
+circuit_connector_definitions["bob-stone-furnace"] = circuit_connector_definitions.create_vector
+(
+  universal_connector_template,
+  {
+    { variation = 18, main_offset = util.by_pixel(1, -9), shadow_offset = util.by_pixel(27.5, 13), show_shadow = false },
+    { variation = 18, main_offset = util.by_pixel(1, -9), shadow_offset = util.by_pixel(27.5, 13), show_shadow = false },
+    { variation = 18, main_offset = util.by_pixel(1, -9), shadow_offset = util.by_pixel(27.5, 13), show_shadow = false },
+    { variation = 18, main_offset = util.by_pixel(1, -9), shadow_offset = util.by_pixel(27.5, 13), show_shadow = false }
+  }
+)
+
+circuit_connector_definitions["bob-steel-furnace"] = circuit_connector_definitions.create_vector
+(
+  universal_connector_template,
+  {
+    { variation = 17, main_offset = util.by_pixel(14, -6), shadow_offset = util.by_pixel(40, 21), show_shadow = true },
+    { variation = 17, main_offset = util.by_pixel(14, -6), shadow_offset = util.by_pixel(40, 21), show_shadow = true },
+    { variation = 17, main_offset = util.by_pixel(14, -6), shadow_offset = util.by_pixel(40, 21), show_shadow = true },
+    { variation = 17, main_offset = util.by_pixel(14, -6), shadow_offset = util.by_pixel(40, 21), show_shadow = true }
+  }
+)
+
+circuit_connector_definitions["bob-electric-furnace"] = circuit_connector_definitions.create_vector
+(
+  universal_connector_template,
+  {
+    { variation = 0, main_offset = util.by_pixel(7, 2), shadow_offset = util.by_pixel(25.5, 30), show_shadow = false },
+    { variation = 0, main_offset = util.by_pixel(7, 2), shadow_offset = util.by_pixel(25.5, 30), show_shadow = false },
+    { variation = 0, main_offset = util.by_pixel(7, 2), shadow_offset = util.by_pixel(25.5, 30), show_shadow = false },
+    { variation = 0, main_offset = util.by_pixel(7, 2), shadow_offset = util.by_pixel(25.5, 30), show_shadow = false }
+  }
+)
+
+circuit_connector_definitions["bob-electric-chemical-furnace"] = circuit_connector_definitions.create_vector
+(
+  universal_connector_template,
+  {
+    { variation = 25, main_offset = util.by_pixel(2, -16), shadow_offset = util.by_pixel(25.5, 30), show_shadow = false },
+    { variation = 25, main_offset = util.by_pixel(2, -16), shadow_offset = util.by_pixel(25.5, 30), show_shadow = false },
+    { variation = 25, main_offset = util.by_pixel(2, -16), shadow_offset = util.by_pixel(25.5, 30), show_shadow = false },
+    { variation = 25, main_offset = util.by_pixel(2, -16), shadow_offset = util.by_pixel(25.5, 30), show_shadow = false }
+  }
+)
+
+circuit_connector_definitions["bob-void-pump"] = circuit_connector_definitions.create_vector
+(
+  universal_connector_template,
+  {
+    { variation = 31, main_offset = util.by_pixel(10, -3), shadow_offset = util.by_pixel(27.5, 13), show_shadow = false },
+    { variation = 30, main_offset = util.by_pixel(-4, 0), shadow_offset = util.by_pixel(27.5, 13), show_shadow = false },
+    { variation = 31, main_offset = util.by_pixel(11, -6), shadow_offset = util.by_pixel(27.5, 13), show_shadow = false },
+    { variation = 30, main_offset = util.by_pixel(-2, 0), shadow_offset = util.by_pixel(27.5, 13), show_shadow = false }
+  }
+)
+
+data.raw.furnace["steel-furnace"].circuit_connector = circuit_connector_definitions["bob-steel-furnace"]
+data.raw.furnace["electric-furnace"].circuit_connector = circuit_connector_definitions["bob-electric-furnace"]
 
 data:extend({
   {
@@ -172,6 +222,8 @@ data:extend({
     flags = { "placeable-neutral", "placeable-player", "player-creation" },
     minable = { mining_time = 0.2, result = "bob-stone-chemical-furnace" },
     max_health = 200,
+    circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
+    circuit_connector = circuit_connector_definitions["bob-stone-furnace"],
     crafting_speed = 1,
     corpse = "medium-remnants",
     repair_sound = { filename = "__base__/sound/manual-repair-simple.ogg" },
@@ -347,6 +399,8 @@ data:extend({
     flags = { "placeable-neutral", "placeable-player", "player-creation" },
     minable = { mining_time = 0.2, result = "bob-steel-chemical-furnace" },
     max_health = 300,
+    circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
+    circuit_connector = circuit_connector_definitions["bob-steel-furnace"],
     crafting_speed = 2,
     corpse = "medium-remnants",
     repair_sound = { filename = "__base__/sound/manual-repair-simple.ogg" },
@@ -419,7 +473,7 @@ data:extend({
     minable = { mining_time = 0.2, result = "bob-electric-chemical-furnace" },
     max_health = 350,
     circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
-    circuit_connector = circuit_connector_definitions["electric-furnace"],
+    circuit_connector = circuit_connector_definitions["bob-electric-chemical-furnace"],
     corpse = "big-remnants",
     resistances = {
       {
@@ -513,6 +567,8 @@ data:extend({
     flags = { "placeable-neutral", "placeable-player", "player-creation" },
     minable = { mining_time = 0.2, result = "bob-stone-mixing-furnace" },
     max_health = 200,
+    circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
+    circuit_connector = circuit_connector_definitions["bob-stone-furnace"],
     corpse = "medium-remnants",
     impact_category = "stone",
     working_sound = {
@@ -586,6 +642,8 @@ data:extend({
     flags = { "placeable-neutral", "placeable-player", "player-creation" },
     minable = { mining_time = 0.2, result = "bob-steel-mixing-furnace" },
     max_health = 300,
+    circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
+    circuit_connector = circuit_connector_definitions["bob-steel-furnace"],
     corpse = "medium-remnants",
     impact_category = "metal",
     working_sound = {
@@ -635,7 +693,7 @@ data:extend({
     minable = { mining_time = 1, result = "bob-electric-mixing-furnace" },
     max_health = 350,
     circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
-    circuit_connector = circuit_connector_definitions["electric-furnace"],
+    circuit_connector = circuit_connector_definitions["bob-electric-furnace"],
     corpse = "big-remnants",
     resistances = {
       {
@@ -966,6 +1024,8 @@ data:extend({
     minable = { mining_time = 1, result = "bob-void-pump" },
     allowed_effects = { "consumption", "speed", "pollution" },
     max_health = 100,
+    circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
+    circuit_connector = circuit_connector_definitions["bob-void-pump"],
     fast_replaceable_group = "pipe",
     corpse = "small-remnants",
     resistances = {

--- a/bobplates/prototypes/entity/pumps.lua
+++ b/bobplates/prototypes/entity/pumps.lua
@@ -76,10 +76,17 @@ local fluid_pump_graphics_set_flipped = {
 
 circuit_connector_definitions["fluid-pump"] =
   circuit_connector_definitions.create_vector(universal_connector_template, {
-    { variation = 0, main_offset = util.by_pixel(3, 0), shadow_offset = util.by_pixel(9, 9), show_shadow = true },
-    { variation = 6, main_offset = util.by_pixel(0, 0), shadow_offset = util.by_pixel(0, 0), show_shadow = false },
-    { variation = 0, main_offset = util.by_pixel(3, 0), shadow_offset = util.by_pixel(9, 9), show_shadow = true },
-    { variation = 6, main_offset = util.by_pixel(0, 0), shadow_offset = util.by_pixel(0, 0), show_shadow = false },
+    { variation = 0, main_offset = util.by_pixel(21, 14), shadow_offset = util.by_pixel(9, 9), show_shadow = false },
+    { variation = 6, main_offset = util.by_pixel(-24, 12), shadow_offset = util.by_pixel(0, 0), show_shadow = false },
+    { variation = 0, main_offset = util.by_pixel(-11, 14), shadow_offset = util.by_pixel(9, 9), show_shadow = false },
+    { variation = 6, main_offset = util.by_pixel(-24, -18), shadow_offset = util.by_pixel(0, 0), show_shadow = false },
+  })
+circuit_connector_definitions["fluid-pump-flipped"] =
+  circuit_connector_definitions.create_vector(universal_connector_template, {
+    { variation = 0, main_offset = util.by_pixel(-11, 14), shadow_offset = util.by_pixel(9, 9), show_shadow = false },
+    { variation = 6, main_offset = util.by_pixel(-24, -20), shadow_offset = util.by_pixel(0, 0), show_shadow = false },
+    { variation = 0, main_offset = util.by_pixel(21, 14), shadow_offset = util.by_pixel(9, 9), show_shadow = false },
+    { variation = 6, main_offset = util.by_pixel(-24, 12), shadow_offset = util.by_pixel(0, 0), show_shadow = false },
   })
 
 data:extend({
@@ -92,6 +99,7 @@ data:extend({
     minable = { mining_time = 1, result = "bob-air-pump" },
     circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
     circuit_connector = circuit_connector_definitions["fluid-pump"],
+    circuit_connector_flipped = circuit_connector_definitions["fluid-pump-flipped"],
     max_health = 150,
     crafting_categories = { "bob-air-pump" },
     crafting_speed = 1,
@@ -159,6 +167,7 @@ data:extend({
     max_health = 180,
     circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
     circuit_connector = circuit_connector_definitions["fluid-pump"],
+    circuit_connector_flipped = circuit_connector_definitions["fluid-pump-flipped"],
     crafting_categories = { "bob-air-pump" },
     crafting_speed = 2,
     module_slots = 2,
@@ -225,6 +234,7 @@ data:extend({
     max_health = 230,
     circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
     circuit_connector = circuit_connector_definitions["fluid-pump"],
+    circuit_connector_flipped = circuit_connector_definitions["fluid-pump-flipped"],
     crafting_categories = { "bob-air-pump" },
     crafting_speed = 3.5,
     module_slots = 4,
@@ -292,6 +302,7 @@ data:extend({
     max_health = 300,
     circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
     circuit_connector = circuit_connector_definitions["fluid-pump"],
+    circuit_connector_flipped = circuit_connector_definitions["fluid-pump-flipped"],
     crafting_categories = { "bob-air-pump" },
     crafting_speed = 5,
     module_slots = 6,
@@ -358,6 +369,7 @@ data:extend({
     max_health = 120,
     circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
     circuit_connector = circuit_connector_definitions["fluid-pump"],
+    circuit_connector_flipped = circuit_connector_definitions["fluid-pump-flipped"],
     crafting_categories = { "bob-water-pump", "barrelling" },
     crafting_speed = 1,
     module_slots = 1,
@@ -424,6 +436,7 @@ data:extend({
     max_health = 180,
     circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
     circuit_connector = circuit_connector_definitions["fluid-pump"],
+    circuit_connector_flipped = circuit_connector_definitions["fluid-pump-flipped"],
     crafting_categories = { "bob-water-pump", "barrelling" },
     crafting_speed = 2,
     module_slots = 2,
@@ -490,6 +503,7 @@ data:extend({
     max_health = 230,
     circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
     circuit_connector = circuit_connector_definitions["fluid-pump"],
+    circuit_connector_flipped = circuit_connector_definitions["fluid-pump-flipped"],
     crafting_categories = { "bob-water-pump", "barrelling" },
     crafting_speed = 3.5,
     module_slots = 4,
@@ -557,6 +571,7 @@ data:extend({
     max_health = 300,
     circuit_wire_max_distance = assembling_machine_circuit_wire_max_distance,
     circuit_connector = circuit_connector_definitions["fluid-pump"],
+    circuit_connector_flipped = circuit_connector_definitions["fluid-pump-flipped"],
     crafting_categories = { "bob-water-pump", "barrelling" },
     crafting_speed = 5,
     module_slots = 6,


### PR DESCRIPTION
Resolves #331 

![new connectors](https://github.com/user-attachments/assets/85deec9d-ad27-4c79-85e2-b266d66c2c10)

Adds circuit connectors to all furnaces, including void pump and distilleries, and updates the connectors on the air/liquid pumps to use circuit_connection_flipped, which looks so much nicer.

For the distilleries, I wanted to put the connector on top of the upright pipe (cooling tank?), but it just barely wouldn't fit.

I updates the connector on the electric furnaces to be closer to what the vanilla version looks like. But in vanilla, the connector weirdly points up for whatever reason. I switched it to pointing down. Chemical and multi furnaces have a different connector, because of that tank on top of them.