### PR TITLE
Fix spidertron military target

### DIFF
--- a/bobenemies/prototypes/categories.lua
+++ b/bobenemies/prototypes/categories.lua
@@ -86,3 +86,10 @@ table.insert(
   "not-fire-unit"
 )
 table.insert(data.raw["utility-constants"].default.default_trigger_target_mask_by_type.unit, "not-fire-unit")
+
+data.raw["utility-constants"].default.default_trigger_target_mask_by_type["spider-vehicle"] = {
+  "common",
+  "ground-unit",
+  "not-electric-unit",
+  "not-fire-unit"
+}

--- a/bobwarfare/prototypes/spidertron.lua
+++ b/bobwarfare/prototypes/spidertron.lua
@@ -369,6 +369,7 @@ function bobmods.warfare.create_spidertron(arguments)
       torso_rotation_speed = arguments.torso_rotation_speed or 0.005,
 
       flags = { "placeable-neutral", "player-creation", "placeable-off-grid" },
+      is_military_target = true,
       mined_sound = { filename = "__core__/sound/deconstruct-large.ogg", volume = 0.8 },
       open_sound = { filename = "__base__/sound/spidertron/spidertron-door-open.ogg", volume = 0.45 },
       close_sound = { filename = "__base__/sound/spidertron/spidertron-door-close.ogg", volume = 0.4 },


### PR DESCRIPTION
Apparently, unlike cars, spider vehicles don't default to is_military_target = true. This fixes that issue. This also gives spider vehicles a default_trigger_target_mask, which they were missing.