### PR TITLE
Move lead solder back to bob-electronics

### DIFF
--- a/bobelectronics/prototypes/technology-updates.lua
+++ b/bobelectronics/prototypes/technology-updates.lua
@@ -33,11 +33,11 @@ bobmods.lib.tech.add_recipe_unlock("plastics", "bob-synthetic-wood")
 if data.raw.recipe["bob-solder"] then
   bobmods.lib.tech.add_recipe_unlock("bob-electronics", "bob-solder")
 end
+if data.raw.recipe["bob-solder-alloy-lead"] then
+  bobmods.lib.tech.add_recipe_unlock("bob-electronics", "bob-solder-alloy-lead")
+end
 if data.raw.recipe["bob-solder-alloy"] then
   bobmods.lib.tech.add_recipe_unlock("bob-electronics", "bob-solder-alloy")
-end
-if data.raw.recipe["bob-solder-alloy-lead"] then
-  bobmods.lib.tech.add_recipe_unlock("bob-lead-processing", "bob-solder-alloy-lead")
 end
 if data.raw.recipe["bob-tinned-copper-cable"] then
   bobmods.lib.tech.add_recipe_unlock("bob-electronics", "bob-tinned-copper-cable")


### PR DESCRIPTION
Moves lead solder alloy recipe unlock back to bob-electronics instead of lead processing. Lead is a starting material, silver is not. Having the only solder alloy recipe that is initially available be the one requires silver is no good.