### PR TITLE
Add missing secondary_draw_order

### DIFF
--- a/bobassembly/prototypes/assembly-electronics.lua
+++ b/bobassembly/prototypes/assembly-electronics.lua
@@ -451,6 +451,7 @@ if settings.startup["bobmods-assembly-electronicmachines"].value == true then
           pipe_connections = {
             { flow_direction = "input", direction = defines.direction.north, position = { 0.5, -0.5 } },
           },
+          secondary_draw_orders = { north = -1 },
           volume = 1000,
         },
       },


### PR DESCRIPTION
The secondary_draw_order parameter wasn't added to fluid boxes for electronics machine 3.