### PR TITLE
Add bob-steel-axe locale

### DIFF
--- a/bobmining/locale/en/bobmining.cfg
+++ b/bobmining/locale/en/bobmining.cfg
@@ -55,6 +55,7 @@ bob-drills=Mining drills research
 bob-area-drills=Large area mining drills research
 bob-pumpjacks=Pumpjacks research
 bob-water-miner=Water pumpjacks research
+bob-steel-axe=Steel axe
 bob-bronze-axe=Bronze axe
 bob-cobalt-steel-axe=Cobalt steel axe
 bob-tungsten-axe=Tungsten axe


### PR DESCRIPTION
Resolves #369

Add locale to be used by steel axe techs if bobplates is not loaded. This is preferable over using localised_name in this case because doing so removed the tier numbers automatically added to the end up the tech name.