### PR TITLE
Add stop_all for Enemies+EnemyRaceManager

### DIFF
--- a/bobenemies/control.lua
+++ b/bobenemies/control.lua
@@ -17,6 +17,9 @@ end
 if script.active_mods["RampantFixed"] and settings.startup["rampantFixed--newEnemies"].value == true then
   bobmods.enemies.stop_all = true
 end
+if script.active_mods["enemyracemanager"] then
+  bobmods.enemies.stop_all = true
+end
 
 if not storage.bobmods then
   storage.bobmods = {}


### PR DESCRIPTION
Resolves #368

Stops scripts for BobEnemies placement when Enemy Race Manager is loaded, to allow that mod to implement its own compatibility solution.