### PR TITLE
Fix productivity in bobelectronics

### DIFF
--- a/bobelectronics/changelog.txt
+++ b/bobelectronics/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.0.2
+Date: ???
+  Bugfixes:
+    - Allowed productivity on Basic Electronic Components and disalowed on Basic Circuit Boards #395
+---------------------------------------------------------------------------------------------------
 Version: 2.0.1
 Date: 05. 04. 2025
   Bugfixes:

--- a/bobelectronics/info.json
+++ b/bobelectronics/info.json
@@ -1,6 +1,6 @@
 {
   "name": "bobelectronics",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "factorio_version": "2.0",
   "title": "Bob's Electronics mod",
   "author": "Bobingabout",

--- a/bobelectronics/prototypes/electronics.lua
+++ b/bobelectronics/prototypes/electronics.lua
@@ -163,6 +163,7 @@ data:extend({
     },
     results = { { type = "item", name = "bob-basic-electronic-components", amount = 5 } },
     allow_decomposition = false,
+    allow_productivity = true,
   },
 })
 
@@ -410,7 +411,6 @@ data:extend({
     },
     results = { { type = "item", name = "bob-basic-circuit-board", amount = 1 } },
     allow_decomposition = false,
-    allow_productivity = true,
   },
 })
 


### PR DESCRIPTION
Adds productivity to basic electronic components, since the line being missing seems like an oversight.

Removes productivity from basic circuit boards, since they are now treated as being the same as the other finished boards, rather than as an intermediate step.