### PR TITLE
Add item-limitation message

### DIFF
--- a/bobplates/locale/en/bobplates.cfg
+++ b/bobplates/locale/en/bobplates.cfg
@@ -381,3 +381,6 @@ computer-age-3=Digital revolution 3
 bob-computer-age-1=Produce 250 advanced processing units per hour.
 bob-computer-age-2=Produce 500 advanced processing units per hour.
 bob-computer-age-3=Produce 2.5k advanced processing units per hour.
+
+[item-limitation]
+consumption-effect=Efficiency-raising modules cannot be used on certain recipes, including all hydrogen electrolysis recipes.


### PR DESCRIPTION
Adds a message for when players attempt to apply an efficiency module to a recipe that can't use them. I believe this should only be hydrogen electrolysis recipes at this point, so that is noted in the message in order to properly inform players of why they're getting the message. Such recipes exist in both Plates and Revamp, but the Revamp recipes should never be added to the game unless Plates is loaded, so the message should only need to be added to Plates.