### PR TITLE
fix: add missing icon_draw_specification in robots declaration

### DIFF
--- a/boblogistics/prototypes/entity/robots.lua
+++ b/boblogistics/prototypes/entity/robots.lua
@@ -7,7 +7,6 @@ function bobmods.logistics.logistic_robot_idle(level)
     line_length = 16,
     width = 80,
     height = 84,
-    frame_count = 1,
     shift = util.by_pixel(0, -3),
     direction_count = 16,
     y = 84,
@@ -22,7 +21,6 @@ function bobmods.logistics.logistic_robot_idle_with_cargo(level)
     line_length = 16,
     width = 80,
     height = 84,
-    frame_count = 1,
     shift = util.by_pixel(0, -3),
     direction_count = 16,
     scale = 0.5,
@@ -51,7 +49,6 @@ function bobmods.logistics.logistic_robot_in_motion_with_cargo(level)
     line_length = 16,
     width = 80,
     height = 84,
-    frame_count = 1,
     shift = util.by_pixel(0, -3),
     direction_count = 16,
     y = 168,
@@ -59,29 +56,61 @@ function bobmods.logistics.logistic_robot_in_motion_with_cargo(level)
   }
 end
 
-bobmods.logistics.logistic_robot_shadow = {
+bobmods.logistics.logistic_robot_shadow_idle = {
   filename = "__boblogistics__/graphics/entity/robots/logistic-robot-shadow.png",
   priority = "high",
   line_length = 16,
   width = 115,
   height = 57,
-  frame_count = 1,
   shift = util.by_pixel(31.75, 19.75),
   direction_count = 16,
   y = 57,
   scale = 0.5,
+  draw_as_shadow = true
 }
 
-bobmods.logistics.logistic_robot_shadow_with_cargo = {
+bobmods.logistics.logistic_robot_shadow_idle_with_cargo = {
   filename = "__boblogistics__/graphics/entity/robots/logistic-robot-shadow.png",
   priority = "high",
   line_length = 16,
   width = 115,
   height = 57,
-  frame_count = 1,
   shift = util.by_pixel(31.75, 19.75),
   direction_count = 16,
   scale = 0.5,
+  draw_as_shadow = true
+}
+
+bobmods.logistics.logistic_robot_shadow_in_motion = {
+  filename = "__boblogistics__/graphics/entity/robots/logistic-robot-shadow.png",
+  priority = "high",
+  line_length = 16,
+  width = 115,
+  height = 57,
+  shift = util.by_pixel(31.75, 19.75),
+  direction_count = 16,
+  y = 171,
+  scale = 0.5,
+  draw_as_shadow = true
+}
+
+bobmods.logistics.logistic_robot_shadow_in_motion_with_cargo = {
+  filename = "__boblogistics__/graphics/entity/robots/logistic-robot-shadow.png",
+  priority = "high",
+  line_length = 16,
+  width = 115,
+  height = 57,
+  shift = util.by_pixel(31.75, 19.75),
+  direction_count = 16,
+  y = 114,
+  scale = 0.5,
+  draw_as_shadow = true
+}
+
+bobmods.logistics.robot_icon_draw_specification = {
+  shift = util.by_pixel(0, -6.4),
+  scale = 0.5,
+  render_layer = "air-entity-info-icon"
 }
 
 data.raw["logistic-robot"]["logistic-robot"].icon = "__boblogistics__/graphics/icons/robots/logistic-robot-1.png"
@@ -90,12 +119,13 @@ data.raw["logistic-robot"]["logistic-robot"].idle = bobmods.logistics.logistic_r
 data.raw["logistic-robot"]["logistic-robot"].idle_with_cargo = bobmods.logistics.logistic_robot_idle_with_cargo(1)
 data.raw["logistic-robot"]["logistic-robot"].in_motion = bobmods.logistics.logistic_robot_in_motion(1)
 data.raw["logistic-robot"]["logistic-robot"].in_motion_with_cargo =
-  bobmods.logistics.logistic_robot_in_motion_with_cargo(1)
-data.raw["logistic-robot"]["logistic-robot"].shadow_idle = bobmods.logistics.logistic_robot_shadow
-data.raw["logistic-robot"]["logistic-robot"].shadow_in_motion = bobmods.logistics.logistic_robot_shadow
-data.raw["logistic-robot"]["logistic-robot"].shadow_idle_with_cargo = bobmods.logistics.logistic_robot_shadow_with_cargo
+    bobmods.logistics.logistic_robot_in_motion_with_cargo(1)
+data.raw["logistic-robot"]["logistic-robot"].shadow_idle = bobmods.logistics.logistic_robot_shadow_idle
+data.raw["logistic-robot"]["logistic-robot"].shadow_in_motion = bobmods.logistics.logistic_robot_shadow_in_motion
+data.raw["logistic-robot"]["logistic-robot"].shadow_idle_with_cargo = bobmods.logistics
+    .logistic_robot_shadow_idle_with_cargo
 data.raw["logistic-robot"]["logistic-robot"].shadow_in_motion_with_cargo =
-  bobmods.logistics.logistic_robot_shadow_with_cargo
+    bobmods.logistics.logistic_robot_shadow_in_motion_with_cargo
 
 data:extend({
   {
@@ -106,9 +136,9 @@ data:extend({
     flags = { "placeable-player", "player-creation", "placeable-off-grid", "not-on-map" },
     minable = { mining_time = 0.1, result = "bob-logistic-robot-2" },
     resistances = {
-      { type = "fire", decrease = 4, percent = 85 },
+      { type = "fire",     decrease = 4, percent = 85 },
       { type = "electric", decrease = 6, percent = 60 },
-      { type = "acid", decrease = 4, percent = 60 },
+      { type = "acid",     decrease = 4, percent = 60 },
     },
     max_health = 125,
     max_payload_size = 3,
@@ -126,16 +156,17 @@ data:extend({
     idle_with_cargo = bobmods.logistics.logistic_robot_idle_with_cargo(2),
     in_motion = bobmods.logistics.logistic_robot_in_motion(2),
     in_motion_with_cargo = bobmods.logistics.logistic_robot_in_motion_with_cargo(2),
-    shadow_idle = bobmods.logistics.logistic_robot_shadow,
-    shadow_in_motion = bobmods.logistics.logistic_robot_shadow,
-    shadow_idle_with_cargo = bobmods.logistics.logistic_robot_shadow_with_cargo,
-    shadow_in_motion_with_cargo = bobmods.logistics.logistic_robot_shadow_with_cargo,
+    shadow_idle = bobmods.logistics.logistic_robot_shadow_idle,
+    shadow_in_motion = bobmods.logistics.logistic_robot_shadow_in_motion,
+    shadow_idle_with_cargo = bobmods.logistics.logistic_robot_shadow_idle_with_cargo,
+    shadow_in_motion_with_cargo = bobmods.logistics.logistic_robot_shadow_in_motion_with_cargo,
     factoriopedia_simulation = {
       init = [[
         game.simulation.camera_position = {0, -1}
         game.surfaces[1].create_entity{name = "bob-logistic-robot-2", position = {0, 0}}
       ]],
     },
+    icon_draw_specification = bobmods.logistics.robot_icon_draw_specification,
   },
 
   {
@@ -146,9 +177,9 @@ data:extend({
     flags = { "placeable-player", "player-creation", "placeable-off-grid", "not-on-map" },
     minable = { mining_time = 0.1, result = "bob-logistic-robot-3" },
     resistances = {
-      { type = "fire", decrease = 8, percent = 85 },
+      { type = "fire",     decrease = 8,  percent = 85 },
       { type = "electric", decrease = 12, percent = 75 },
-      { type = "acid", decrease = 8, percent = 65 },
+      { type = "acid",     decrease = 8,  percent = 65 },
     },
     max_health = 150,
     max_payload_size = 6,
@@ -166,16 +197,18 @@ data:extend({
     idle_with_cargo = bobmods.logistics.logistic_robot_idle_with_cargo(3),
     in_motion = bobmods.logistics.logistic_robot_in_motion(3),
     in_motion_with_cargo = bobmods.logistics.logistic_robot_in_motion_with_cargo(3),
-    shadow_idle = bobmods.logistics.logistic_robot_shadow,
-    shadow_in_motion = bobmods.logistics.logistic_robot_shadow,
-    shadow_idle_with_cargo = bobmods.logistics.logistic_robot_shadow_with_cargo,
-    shadow_in_motion_with_cargo = bobmods.logistics.logistic_robot_shadow_with_cargo,
+    shadow_idle = bobmods.logistics.logistic_robot_shadow_idle,
+    shadow_in_motion = bobmods.logistics.logistic_robot_shadow_in_motion,
+    shadow_idle_with_cargo = bobmods.logistics.logistic_robot_shadow_idle_with_cargo,
+    shadow_in_motion_with_cargo = bobmods.logistics.logistic_robot_shadow_in_motion_with_cargo,
     factoriopedia_simulation = {
       init = [[
         game.simulation.camera_position = {0, -1}
         game.surfaces[1].create_entity{name = "bob-logistic-robot-3", position = {0, 0}}
       ]],
     },
+    icon_draw_specification = bobmods.logistics.robot_icon_draw_specification,
+
   },
 
   {
@@ -186,9 +219,9 @@ data:extend({
     flags = { "placeable-player", "player-creation", "placeable-off-grid", "not-on-map" },
     minable = { mining_time = 0.1, result = "bob-logistic-robot-4" },
     resistances = {
-      { type = "fire", decrease = 12, percent = 90 },
+      { type = "fire",     decrease = 12, percent = 90 },
       { type = "electric", decrease = 20, percent = 90 },
-      { type = "acid", decrease = 12, percent = 70 },
+      { type = "acid",     decrease = 12, percent = 70 },
     },
     max_health = 175,
     max_payload_size = 11,
@@ -206,16 +239,18 @@ data:extend({
     idle_with_cargo = bobmods.logistics.logistic_robot_idle_with_cargo(4),
     in_motion = bobmods.logistics.logistic_robot_in_motion(4),
     in_motion_with_cargo = bobmods.logistics.logistic_robot_in_motion_with_cargo(4),
-    shadow_idle = bobmods.logistics.logistic_robot_shadow,
-    shadow_in_motion = bobmods.logistics.logistic_robot_shadow,
-    shadow_idle_with_cargo = bobmods.logistics.logistic_robot_shadow_with_cargo,
-    shadow_in_motion_with_cargo = bobmods.logistics.logistic_robot_shadow_with_cargo,
+    shadow_idle = bobmods.logistics.logistic_robot_shadow_idle,
+    shadow_in_motion = bobmods.logistics.logistic_robot_shadow_in_motion,
+    shadow_idle_with_cargo = bobmods.logistics.logistic_robot_shadow_idle_with_cargo,
+    shadow_in_motion_with_cargo = bobmods.logistics.logistic_robot_shadow_in_motion_with_cargo,
     factoriopedia_simulation = {
       init = [[
         game.simulation.camera_position = {0, -1}
         game.surfaces[1].create_entity{name = "bob-logistic-robot-4", position = {0, 0}}
       ]],
     },
+    icon_draw_specification = bobmods.logistics.robot_icon_draw_specification,
+
   },
 
   {
@@ -226,9 +261,9 @@ data:extend({
     flags = { "placeable-player", "player-creation", "placeable-off-grid", "not-on-map" },
     minable = { mining_time = 0.1, result = "bob-logistic-robot-5" },
     resistances = {
-      { type = "fire", decrease = 12, percent = 90 },
+      { type = "fire",     decrease = 12, percent = 90 },
       { type = "electric", decrease = 20, percent = 90 },
-      { type = "acid", decrease = 12, percent = 70 },
+      { type = "acid",     decrease = 12, percent = 70 },
     },
     max_health = 175,
     max_payload_size = 11,
@@ -246,16 +281,18 @@ data:extend({
     idle_with_cargo = bobmods.logistics.logistic_robot_idle_with_cargo(5),
     in_motion = bobmods.logistics.logistic_robot_in_motion(5),
     in_motion_with_cargo = bobmods.logistics.logistic_robot_in_motion_with_cargo(5),
-    shadow_idle = bobmods.logistics.logistic_robot_shadow,
-    shadow_in_motion = bobmods.logistics.logistic_robot_shadow,
-    shadow_idle_with_cargo = bobmods.logistics.logistic_robot_shadow_with_cargo,
-    shadow_in_motion_with_cargo = bobmods.logistics.logistic_robot_shadow_with_cargo,
+    shadow_idle = bobmods.logistics.logistic_robot_shadow_idle,
+    shadow_in_motion = bobmods.logistics.logistic_robot_shadow_in_motion,
+    shadow_idle_with_cargo = bobmods.logistics.logistic_robot_shadow_idle_with_cargo,
+    shadow_in_motion_with_cargo = bobmods.logistics.logistic_robot_shadow_in_motion_with_cargo,
     factoriopedia_simulation = {
       init = [[
         game.simulation.camera_position = {0, -1}
         game.surfaces[1].create_entity{name = "bob-logistic-robot-5", position = {0, 0}}
       ]],
     },
+    icon_draw_specification = bobmods.logistics.robot_icon_draw_specification,
+
   },
 })
 
@@ -266,7 +303,6 @@ function bobmods.logistics.construction_robot_idle(level)
     line_length = 16,
     width = 66,
     height = 76,
-    frame_count = 1,
     shift = util.by_pixel(0, -4.5),
     direction_count = 16,
     scale = 0.5,
@@ -280,7 +316,6 @@ function bobmods.logistics.construction_robot_in_motion(level)
     line_length = 16,
     width = 66,
     height = 76,
-    frame_count = 1,
     shift = util.by_pixel(0, -4.5),
     direction_count = 16,
     y = 76,
@@ -303,16 +338,28 @@ function bobmods.logistics.construction_robot_working(level)
   }
 end
 
-bobmods.logistics.construction_robot_shadow = {
+bobmods.logistics.construction_robot_shadow_idle = {
   filename = "__boblogistics__/graphics/entity/robots/construction-robot-shadow.png",
   priority = "high",
   line_length = 16,
   width = 104,
   height = 49,
-  frame_count = 1,
   shift = util.by_pixel(33.5, 18.75),
   direction_count = 16,
   scale = 0.5,
+  draw_as_shadow = true
+}
+
+bobmods.logistics.construction_robot_shadow_in_motion = {
+  filename = "__boblogistics__/graphics/entity/robots/construction-robot-shadow.png",
+  priority = "high",
+  line_length = 16,
+  width = 104,
+  height = 49,
+  shift = util.by_pixel(33.5, 18.75),
+  direction_count = 16,
+  scale = 0.5,
+  draw_as_shadow = true
 }
 
 bobmods.logistics.construction_robot_shadow_working = {
@@ -331,26 +378,27 @@ bobmods.logistics.construction_robot_shadow_working = {
   shift = util.by_pixel(33.5, 18.75),
   direction_count = 16,
   scale = 0.5,
+  draw_as_shadow = true
 }
 
-bobmods.logistics.robot_smoke = {
+bobmods.logistics.construction_robot_smoke = {
   filename = "__base__/graphics/entity/smoke-construction/smoke-01.png",
   width = 39,
   height = 32,
   frame_count = 19,
   line_length = 19,
-  shift = { 0.078125, -0.15625 },
+  shift = util.by_pixel(2.5, -5),
   animation_speed = 0.3,
 }
 
-bobmods.logistics.robot_sparks = {
+bobmods.logistics.construction_robot_sparks = {
   {
     filename = "__base__/graphics/entity/sparks/sparks-01.png",
     width = 39,
     height = 34,
     frame_count = 19,
     line_length = 19,
-    shift = { -0.109375, 0.3125 },
+    shift = util.by_pixel(-3.5, 10),
     tint = { r = 1.0, g = 0.9, b = 0.0, a = 1.0 },
     animation_speed = 0.3,
   },
@@ -360,7 +408,7 @@ bobmods.logistics.robot_sparks = {
     height = 32,
     frame_count = 19,
     line_length = 19,
-    shift = { 0.03125, 0.125 },
+    shift = util.by_pixel(1, 4),
     tint = { r = 1.0, g = 0.9, b = 0.0, a = 1.0 },
     animation_speed = 0.3,
   },
@@ -370,7 +418,7 @@ bobmods.logistics.robot_sparks = {
     height = 29,
     frame_count = 19,
     line_length = 19,
-    shift = { -0.0625, 0.203125 },
+    shift = util.by_pixel(-2, 6.5),
     tint = { r = 1.0, g = 0.9, b = 0.0, a = 1.0 },
     animation_speed = 0.3,
   },
@@ -380,7 +428,7 @@ bobmods.logistics.robot_sparks = {
     height = 35,
     frame_count = 19,
     line_length = 19,
-    shift = { -0.0625, 0.234375 },
+    shift = util.by_pixel(-2, 7.5),
     tint = { r = 1.0, g = 0.9, b = 0.0, a = 1.0 },
     animation_speed = 0.3,
   },
@@ -390,7 +438,7 @@ bobmods.logistics.robot_sparks = {
     height = 29,
     frame_count = 19,
     line_length = 19,
-    shift = { -0.109375, 0.171875 },
+    shift = util.by_pixel(-3.5, 5.5),
     tint = { r = 1.0, g = 0.9, b = 0.0, a = 1.0 },
     animation_speed = 0.3,
   },
@@ -400,22 +448,23 @@ bobmods.logistics.robot_sparks = {
     height = 36,
     frame_count = 19,
     line_length = 19,
-    shift = { 0.03125, 0.3125 },
+    shift = util.by_pixel(1, 10),
     tint = { r = 1.0, g = 0.9, b = 0.0, a = 1.0 },
     animation_speed = 0.3,
   },
 }
 
 data.raw["construction-robot"]["construction-robot"].icon =
-  "__boblogistics__/graphics/icons/robots/construction-robot-1.png"
+"__boblogistics__/graphics/icons/robots/construction-robot-1.png"
 data.raw["construction-robot"]["construction-robot"].icon_size = 32
 data.raw["construction-robot"]["construction-robot"].idle = bobmods.logistics.construction_robot_idle(1)
 data.raw["construction-robot"]["construction-robot"].in_motion = bobmods.logistics.construction_robot_in_motion(1)
 data.raw["construction-robot"]["construction-robot"].working = bobmods.logistics.construction_robot_working(1)
-data.raw["construction-robot"]["construction-robot"].shadow_idle = bobmods.logistics.construction_robot_shadow
-data.raw["construction-robot"]["construction-robot"].shadow_in_motion = bobmods.logistics.construction_robot_shadow
+data.raw["construction-robot"]["construction-robot"].shadow_idle = bobmods.logistics.construction_robot_shadow_idle
+data.raw["construction-robot"]["construction-robot"].shadow_in_motion = bobmods.logistics
+    .construction_robot_shadow_in_motion
 data.raw["construction-robot"]["construction-robot"].shadow_working =
-  bobmods.logistics.construction_robot_shadow_working
+    bobmods.logistics.construction_robot_shadow_working
 
 data:extend({
   {
@@ -426,9 +475,9 @@ data:extend({
     flags = { "placeable-player", "player-creation", "placeable-off-grid", "not-on-map" },
     minable = { mining_time = 0.1, result = "bob-construction-robot-2" },
     resistances = {
-      { type = "fire", decrease = 4, percent = 85 },
+      { type = "fire",     decrease = 4, percent = 85 },
       { type = "electric", decrease = 6, percent = 60 },
-      { type = "acid", decrease = 4, percent = 60 },
+      { type = "acid",     decrease = 4, percent = 60 },
     },
     max_health = 225,
     max_payload_size = 2,
@@ -447,17 +496,18 @@ data:extend({
     idle = bobmods.logistics.construction_robot_idle(2),
     in_motion = bobmods.logistics.construction_robot_in_motion(2),
     working = bobmods.logistics.construction_robot_working(2),
-    shadow_idle = bobmods.logistics.construction_robot_shadow,
-    shadow_in_motion = bobmods.logistics.construction_robot_shadow,
+    shadow_idle = bobmods.logistics.construction_robot_shadow_idle,
+    shadow_in_motion = bobmods.logistics.construction_robot_shadow_in_motion,
     shadow_working = bobmods.logistics.construction_robot_shadow_working,
-    smoke = bobmods.logistics.robot_smoke,
-    sparks = bobmods.logistics.robot_sparks,
+    smoke = bobmods.logistics.construction_robot_smoke,
+    sparks = bobmods.logistics.construction_robot_sparks,
     factoriopedia_simulation = {
       init = [[
         game.simulation.camera_position = {0, -1}
         game.surfaces[1].create_entity{name = "bob-construction-robot-2", position = {0, 0}}
       ]],
     },
+    icon_draw_specification = bobmods.logistics.robot_icon_draw_specification,
   },
 
   {
@@ -468,9 +518,9 @@ data:extend({
     flags = { "placeable-player", "player-creation", "placeable-off-grid", "not-on-map" },
     minable = { mining_time = 0.1, result = "bob-construction-robot-3" },
     resistances = {
-      { type = "fire", decrease = 8, percent = 85 },
+      { type = "fire",     decrease = 8,  percent = 85 },
       { type = "electric", decrease = 12, percent = 75 },
-      { type = "acid", decrease = 8, percent = 65 },
+      { type = "acid",     decrease = 8,  percent = 65 },
     },
     max_health = 350,
     max_payload_size = 4,
@@ -489,17 +539,18 @@ data:extend({
     idle = bobmods.logistics.construction_robot_idle(3),
     in_motion = bobmods.logistics.construction_robot_in_motion(3),
     working = bobmods.logistics.construction_robot_working(3),
-    shadow_idle = bobmods.logistics.construction_robot_shadow,
-    shadow_in_motion = bobmods.logistics.construction_robot_shadow,
+    shadow_idle = bobmods.logistics.construction_robot_shadow_idle,
+    shadow_in_motion = bobmods.logistics.construction_robot_shadow_in_motion,
     shadow_working = bobmods.logistics.construction_robot_shadow_working,
-    smoke = bobmods.logistics.robot_smoke,
-    sparks = bobmods.logistics.robot_sparks,
+    smoke = bobmods.logistics.construction_robot_smoke,
+    sparks = bobmods.logistics.construction_robot_sparks,
     factoriopedia_simulation = {
       init = [[
         game.simulation.camera_position = {0, -1}
         game.surfaces[1].create_entity{name = "bob-construction-robot-3", position = {0, 0}}
       ]],
     },
+    icon_draw_specification = bobmods.logistics.robot_icon_draw_specification,
   },
 
   {
@@ -510,9 +561,9 @@ data:extend({
     flags = { "placeable-player", "player-creation", "placeable-off-grid", "not-on-map" },
     minable = { mining_time = 0.1, result = "bob-construction-robot-4" },
     resistances = {
-      { type = "fire", decrease = 12, percent = 90 },
+      { type = "fire",     decrease = 12, percent = 90 },
       { type = "electric", decrease = 20, percent = 90 },
-      { type = "acid", decrease = 12, percent = 70 },
+      { type = "acid",     decrease = 12, percent = 70 },
     },
     max_health = 500,
     max_payload_size = 6,
@@ -531,17 +582,18 @@ data:extend({
     idle = bobmods.logistics.construction_robot_idle(4),
     in_motion = bobmods.logistics.construction_robot_in_motion(4),
     working = bobmods.logistics.construction_robot_working(4),
-    shadow_idle = bobmods.logistics.construction_robot_shadow,
-    shadow_in_motion = bobmods.logistics.construction_robot_shadow,
+    shadow_idle = bobmods.logistics.construction_robot_shadow_idle,
+    shadow_in_motion = bobmods.logistics.construction_robot_shadow_in_motion,
     shadow_working = bobmods.logistics.construction_robot_shadow_working,
-    smoke = bobmods.logistics.robot_smoke,
-    sparks = bobmods.logistics.robot_sparks,
+    smoke = bobmods.logistics.construction_robot_smoke,
+    sparks = bobmods.logistics.construction_robot_sparks,
     factoriopedia_simulation = {
       init = [[
         game.simulation.camera_position = {0, -1}
         game.surfaces[1].create_entity{name = "bob-construction-robot-4", position = {0, 0}}
       ]],
     },
+    icon_draw_specification = bobmods.logistics.robot_icon_draw_specification,
   },
 
   {
@@ -552,9 +604,9 @@ data:extend({
     flags = { "placeable-player", "player-creation", "placeable-off-grid", "not-on-map" },
     minable = { mining_time = 0.1, result = "bob-construction-robot-5" },
     resistances = {
-      { type = "fire", decrease = 12, percent = 90 },
+      { type = "fire",     decrease = 12, percent = 90 },
       { type = "electric", decrease = 20, percent = 90 },
-      { type = "acid", decrease = 12, percent = 70 },
+      { type = "acid",     decrease = 12, percent = 70 },
     },
     max_health = 500,
     max_payload_size = 6,
@@ -573,16 +625,17 @@ data:extend({
     idle = bobmods.logistics.construction_robot_idle(5),
     in_motion = bobmods.logistics.construction_robot_in_motion(5),
     working = bobmods.logistics.construction_robot_working(5),
-    shadow_idle = bobmods.logistics.construction_robot_shadow,
-    shadow_in_motion = bobmods.logistics.construction_robot_shadow,
+    shadow_idle = bobmods.logistics.construction_robot_shadow_idle,
+    shadow_in_motion = bobmods.logistics.construction_robot_shadow_in_motion,
     shadow_working = bobmods.logistics.construction_robot_shadow_working,
-    smoke = bobmods.logistics.robot_smoke,
-    sparks = bobmods.logistics.robot_sparks,
+    smoke = bobmods.logistics.construction_robot_smoke,
+    sparks = bobmods.logistics.construction_robot_sparks,
     factoriopedia_simulation = {
       init = [[
         game.simulation.camera_position = {0, -1}
         game.surfaces[1].create_entity{name = "bob-construction-robot-5", position = {0, 0}}
       ]],
     },
+    icon_draw_specification = bobmods.logistics.robot_icon_draw_specification,
   },
 })


### PR DESCRIPTION
I added the missing `icon_draw_specification` property in logistic and construction robots. This should close issue #404.

Also I mapped some properties to match exactly as they are in the current base game. This way we make sure that the vanilla robots and the modded robots will behave the same.

This how construction robots looks now

![image](https://github.com/user-attachments/assets/89287caf-6506-4512-8177-4bb290b425b4)

And this is how logistic robots looks now

![image](https://github.com/user-attachments/assets/905696df-80f5-4c94-a1a4-7097e9bc4e71)
