### PR TITLE
Fix bug 427: Handle mod conflict for nuclear-fuel-reprocessing recipe.

### DIFF
--- a/bobplates/changelog.txt
+++ b/bobplates/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.0.3
+Date: ???
+  Bugfixes:
+    - Fixed crafting_machine_tint startup error when using other mods that also modify the nuclear fuel reprocessing recipe #427
+---------------------------------------------------------------------------------------------------
 Version: 2.0.2
 Date: 20. 04. 2025
   Bugfixes:

--- a/bobplates/data-updates.lua
+++ b/bobplates/data-updates.lua
@@ -126,7 +126,11 @@ if settings.startup["bobmods-plates-nuclearupdate"].value == true then
   data.raw.recipe["nuclear-fuel-reprocessing"].icon =
     "__bobplates__/graphics/icons/nuclear/nuclear-fuel-reprocessing.png"
   data.raw.recipe["nuclear-fuel-reprocessing"].icon_size = 32
-  data.raw.recipe["nuclear-fuel-reprocessing"].crafting_machine_tint.secondary = { r = 1, g = 0.7, b = 0 } --Right hand module glows plutonium orange-yellow.
+
+  -- #427 Since we initialize crafting_machine_tint in the earlier data stage, another mod may have modified the recipe in between.
+  if data.raw.recipe["nuclear-fuel-reprocessing"].crafting_machine_tint then
+     data.raw.recipe["nuclear-fuel-reprocessing"].crafting_machine_tint.secondary = { r = 1, g = 0.7, b = 0 } --Right hand module glows plutonium orange-yellow.
+  end
 
   data.raw.recipe["nuclear-fuel-reprocessing"].energy_required = 120 --up from 60
   bobmods.lib.recipe.add_ingredient(


### PR DESCRIPTION
Currently the crafting_machine_tint is initialized in the data phase but modified in the data-update phase.
Ideally both parts would happen in the same stage, but given the maturity of bobmods it seems prudent to make the least disruptive fix.