### PR TITLE
Decrease cost of cordite

### DIFF
--- a/bobwarfare/changelog.txt
+++ b/bobwarfare/changelog.txt
@@ -6,6 +6,7 @@ Date: ???
     - Reduce the cost of Rockets #428
     - Blue Alien Alloy takes Cobalt Steel instead of Tungsten #429
     - Added zh-TW locale #432
+    - Reduce the cost of Cordite #437
 ---------------------------------------------------------------------------------------------------
 Version: 2.0.2
 Date: 20. 04. 2025

--- a/bobwarfare/prototypes/recipe/parts-recipe.lua
+++ b/bobwarfare/prototypes/recipe/parts-recipe.lua
@@ -39,8 +39,8 @@ data:extend({
     enabled = false,
     auto_recycle = false,
     ingredients = {
-      { type = "fluid", name = "bob-nitroglycerin", amount = 60 },
-      { type = "item", name = "bob-gun-cotton", amount = 13 },
+      { type = "fluid", name = "bob-nitroglycerin", amount = 20 },
+      { type = "item", name = "bob-gun-cotton", amount = 5 },
       { type = "item", name = "bob-petroleum-jelly", amount = 1 },
     },
     results = { { type = "item", name = "bob-cordite", amount = 5 } },


### PR DESCRIPTION
Decreases the cost of a set of 5 cordite. Reduces nitroglycerin from 60 to 20 and guncotton from 13 to 5. To be honest, it's always been very expensive, and a major impediment to upgrading from red ammo to black ammo, and with the new enemies, that's a fairly significant problem. Relates to #418, though I wouldn't say this definitely resolves that issue.