### PR TITLE
Revise artifact drops

### DIFF
--- a/bobenemies/data-updates.lua
+++ b/bobenemies/data-updates.lua
@@ -8,25 +8,17 @@ then
     if data.raw.unit["small-biter"].loot == nil then
       data.raw.unit["small-biter"].loot = {}
     end
-    table.insert(
-      data.raw.unit["small-biter"].loot,
-      { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
-    )
 
     if data.raw.unit["small-spitter"].loot == nil then
       data.raw.unit["small-spitter"].loot = {}
     end
-    table.insert(
-      data.raw.unit["small-spitter"].loot,
-      { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
-    )
 
     if data.raw.unit["medium-biter"].loot == nil then
       data.raw.unit["medium-biter"].loot = {}
     end
     table.insert(
       data.raw.unit["medium-biter"].loot,
-      { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
+      { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
     )
 
     if data.raw.unit["medium-spitter"].loot == nil then
@@ -34,7 +26,7 @@ then
     end
     table.insert(
       data.raw.unit["medium-spitter"].loot,
-      { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
+      { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
     )
 
     if data.raw.unit["big-biter"].loot == nil then
@@ -42,7 +34,7 @@ then
     end
     table.insert(
       data.raw.unit["big-biter"].loot,
-      { item = "bob-small-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+      { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
     )
 
     if data.raw.unit["big-spitter"].loot == nil then
@@ -50,32 +42,32 @@ then
     end
     table.insert(
       data.raw.unit["big-spitter"].loot,
-      { item = "bob-small-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+      { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
     )
 
     table.insert(
       data.raw.unit["bob-huge-biter"].loot,
-      { item = "bob-small-alien-artifact", count_min = 2, count_max = 5, probability = 1 }
+      { item = "bob-small-alien-artifact", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.unit["bob-huge-spitter"].loot,
-      { item = "bob-small-alien-artifact", count_min = 2, count_max = 5, probability = 1 }
+      { item = "bob-small-alien-artifact", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.unit["bob-giant-biter"].loot,
-      { item = "bob-small-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+      { item = "bob-small-alien-artifact", count_min = 3, count_max = 5 }
     )
     table.insert(
       data.raw.unit["bob-giant-spitter"].loot,
-      { item = "bob-small-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+      { item = "bob-small-alien-artifact", count_min = 3, count_max = 5 }
     )
     table.insert(
       data.raw.unit["bob-titan-biter"].loot,
-      { item = "bob-small-alien-artifact", count_min = 5, count_max = 11, probability = 1 }
+      { item = "bob-small-alien-artifact", count_min = 5, count_max = 8 }
     )
     table.insert(
       data.raw.unit["bob-titan-spitter"].loot,
-      { item = "bob-small-alien-artifact", count_min = 5, count_max = 11, probability = 1 }
+      { item = "bob-small-alien-artifact", count_min = 5, count_max = 8 }
     )
 
     if data.raw.unit["behemoth-biter"].loot == nil then
@@ -87,7 +79,7 @@ then
     if settings.startup["bobmods-enemies-enablenewartifacts"].value == true then
       table.insert(
         data.raw.unit["behemoth-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 7, count_max = 10, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["behemoth-biter"].loot,
@@ -104,7 +96,7 @@ then
 
       table.insert(
         data.raw.unit["behemoth-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 7, count_max = 10, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["behemoth-spitter"].loot,
@@ -122,7 +114,7 @@ then
       --Duplicated with and without small artifacts
       table.insert(
         data.raw.unit["bob-leviathan-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 2, count_max = 3, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 2, count_max = 3 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-biter"].loot,
@@ -151,7 +143,7 @@ then
 
       table.insert(
         data.raw.unit["bob-leviathan-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 2, count_max = 3, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 2, count_max = 3 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-spitter"].loot,
@@ -179,306 +171,257 @@ then
       )
 
       table.insert(
-        data.raw.unit["bob-small-piercing-biter"].loot,
-        { item = "bob-small-alien-artifact-blue", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-piercing-spitter"].loot,
-        { item = "bob-small-alien-artifact-blue", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-electric-biter"].loot,
-        { item = "bob-small-alien-artifact-orange", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-electric-spitter"].loot,
-        { item = "bob-small-alien-artifact-orange", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-acid-biter"].loot,
-        { item = "bob-small-alien-artifact-purple", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-acid-spitter"].loot,
-        { item = "bob-small-alien-artifact-purple", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-explosive-biter"].loot,
-        { item = "bob-small-alien-artifact-yellow", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-explosive-spitter"].loot,
-        { item = "bob-small-alien-artifact-yellow", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-poison-biter"].loot,
-        { item = "bob-small-alien-artifact-green", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-poison-spitter"].loot,
-        { item = "bob-small-alien-artifact-green", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-fire-biter"].loot,
-        { item = "bob-small-alien-artifact-red", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-fire-spitter"].loot,
-        { item = "bob-small-alien-artifact-red", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-
-      table.insert(
         data.raw.unit["bob-medium-piercing-biter"].loot,
-        { item = "bob-small-alien-artifact-blue", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact-blue", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-piercing-spitter"].loot,
-        { item = "bob-small-alien-artifact-blue", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact-blue", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-electric-biter"].loot,
-        { item = "bob-small-alien-artifact-orange", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact-orange", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-electric-spitter"].loot,
-        { item = "bob-small-alien-artifact-orange", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact-orange", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-acid-biter"].loot,
-        { item = "bob-small-alien-artifact-purple", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact-purple", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-acid-spitter"].loot,
-        { item = "bob-small-alien-artifact-purple", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact-purple", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-explosive-biter"].loot,
-        { item = "bob-small-alien-artifact-yellow", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact-yellow", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-explosive-spitter"].loot,
-        { item = "bob-small-alien-artifact-yellow", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact-yellow", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-poison-biter"].loot,
-        { item = "bob-small-alien-artifact-green", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact-green", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-poison-spitter"].loot,
-        { item = "bob-small-alien-artifact-green", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact-green", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-fire-biter"].loot,
-        { item = "bob-small-alien-artifact-red", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact-red", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-fire-spitter"].loot,
-        { item = "bob-small-alien-artifact-red", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact-red", count_min = 1, count_max = 1, probability = 0.5 }
       )
 
       table.insert(
         data.raw.unit["bob-big-piercing-biter"].loot,
-        { item = "bob-small-alien-artifact-blue", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact-blue", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-piercing-spitter"].loot,
-        { item = "bob-small-alien-artifact-blue", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact-blue", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-electric-biter"].loot,
-        { item = "bob-small-alien-artifact-orange", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact-orange", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-electric-spitter"].loot,
-        { item = "bob-small-alien-artifact-orange", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact-orange", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-acid-biter"].loot,
-        { item = "bob-small-alien-artifact-purple", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact-purple", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-acid-spitter"].loot,
-        { item = "bob-small-alien-artifact-purple", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact-purple", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-explosive-biter"].loot,
-        { item = "bob-small-alien-artifact-yellow", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact-yellow", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-explosive-spitter"].loot,
-        { item = "bob-small-alien-artifact-yellow", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact-yellow", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-poison-biter"].loot,
-        { item = "bob-small-alien-artifact-green", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact-green", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-poison-spitter"].loot,
-        { item = "bob-small-alien-artifact-green", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact-green", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-fire-biter"].loot,
-        { item = "bob-small-alien-artifact-red", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact-red", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-fire-spitter"].loot,
-        { item = "bob-small-alien-artifact-red", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact-red", count_min = 1, count_max = 3, probability = 0.75 }
       )
 
       table.insert(
         data.raw.unit["bob-huge-piercing-biter"].loot,
-        { item = "bob-small-alien-artifact-blue", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact-blue", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-piercing-spitter"].loot,
-        { item = "bob-small-alien-artifact-blue", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact-blue", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-electric-biter"].loot,
-        { item = "bob-small-alien-artifact-orange", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact-orange", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-electric-spitter"].loot,
-        { item = "bob-small-alien-artifact-orange", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact-orange", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-acid-biter"].loot,
-        { item = "bob-small-alien-artifact-purple", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact-purple", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-acid-spitter"].loot,
-        { item = "bob-small-alien-artifact-purple", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact-purple", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-explosive-biter"].loot,
-        { item = "bob-small-alien-artifact-yellow", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact-yellow", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-explosive-spitter"].loot,
-        { item = "bob-small-alien-artifact-yellow", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact-yellow", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-poison-biter"].loot,
-        { item = "bob-small-alien-artifact-green", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact-green", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-poison-spitter"].loot,
-        { item = "bob-small-alien-artifact-green", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact-green", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-fire-biter"].loot,
-        { item = "bob-small-alien-artifact-red", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact-red", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-fire-spitter"].loot,
-        { item = "bob-small-alien-artifact-red", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact-red", count_min = 2, count_max = 4 }
       )
 
       table.insert(
         data.raw.unit["bob-giant-piercing-biter"].loot,
-        { item = "bob-small-alien-artifact-blue", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact-blue", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-piercing-spitter"].loot,
-        { item = "bob-small-alien-artifact-blue", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact-blue", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-electric-biter"].loot,
-        { item = "bob-small-alien-artifact-orange", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact-orange", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-electric-spitter"].loot,
-        { item = "bob-small-alien-artifact-orange", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact-orange", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-acid-biter"].loot,
-        { item = "bob-small-alien-artifact-purple", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact-purple", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-acid-spitter"].loot,
-        { item = "bob-small-alien-artifact-purple", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact-purple", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-explosive-biter"].loot,
-        { item = "bob-small-alien-artifact-yellow", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact-yellow", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-explosive-spitter"].loot,
-        { item = "bob-small-alien-artifact-yellow", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact-yellow", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-poison-biter"].loot,
-        { item = "bob-small-alien-artifact-green", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact-green", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-poison-spitter"].loot,
-        { item = "bob-small-alien-artifact-green", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact-green", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-fire-biter"].loot,
-        { item = "bob-small-alien-artifact-red", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact-red", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-fire-spitter"].loot,
-        { item = "bob-small-alien-artifact-red", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact-red", count_min = 3, count_max = 5 }
       )
 
       table.insert(
         data.raw.unit["bob-titan-piercing-biter"].loot,
-        { item = "bob-small-alien-artifact-blue", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact-blue", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-piercing-spitter"].loot,
-        { item = "bob-small-alien-artifact-blue", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact-blue", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-electric-biter"].loot,
-        { item = "bob-small-alien-artifact-orange", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact-orange", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-electric-spitter"].loot,
-        { item = "bob-small-alien-artifact-orange", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact-orange", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-acid-biter"].loot,
-        { item = "bob-small-alien-artifact-purple", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact-purple", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-acid-spitter"].loot,
-        { item = "bob-small-alien-artifact-purple", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact-purple", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-explosive-biter"].loot,
-        { item = "bob-small-alien-artifact-yellow", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact-yellow", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-explosive-spitter"].loot,
-        { item = "bob-small-alien-artifact-yellow", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact-yellow", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-poison-biter"].loot,
-        { item = "bob-small-alien-artifact-green", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact-green", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-poison-spitter"].loot,
-        { item = "bob-small-alien-artifact-green", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact-green", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-fire-biter"].loot,
-        { item = "bob-small-alien-artifact-red", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact-red", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-fire-spitter"].loot,
-        { item = "bob-small-alien-artifact-red", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact-red", count_min = 5, count_max = 8 }
       )
 
       table.insert(
         data.raw.unit["bob-behemoth-piercing-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-piercing-biter"].loot,
-        { item = "bob-small-alien-artifact-blue", count_min = 6, count_max = 10, probability = 1 }
+        { item = "bob-small-alien-artifact-blue", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-piercing-biter"].loot,
@@ -487,11 +430,11 @@ then
 
       table.insert(
         data.raw.unit["bob-behemoth-piercing-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-piercing-spitter"].loot,
-        { item = "bob-small-alien-artifact-blue", count_min = 6, count_max = 10, probability = 1 }
+        { item = "bob-small-alien-artifact-blue", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-piercing-spitter"].loot,
@@ -500,11 +443,11 @@ then
 
       table.insert(
         data.raw.unit["bob-behemoth-electric-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-electric-biter"].loot,
-        { item = "bob-small-alien-artifact-orange", count_min = 6, count_max = 10, probability = 1 }
+        { item = "bob-small-alien-artifact-orange", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-electric-biter"].loot,
@@ -513,11 +456,11 @@ then
 
       table.insert(
         data.raw.unit["bob-behemoth-electric-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-electric-spitter"].loot,
-        { item = "bob-small-alien-artifact-orange", count_min = 6, count_max = 10, probability = 1 }
+        { item = "bob-small-alien-artifact-orange", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-electric-spitter"].loot,
@@ -526,11 +469,11 @@ then
 
       table.insert(
         data.raw.unit["bob-behemoth-acid-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-acid-biter"].loot,
-        { item = "bob-small-alien-artifact-purple", count_min = 6, count_max = 10, probability = 1 }
+        { item = "bob-small-alien-artifact-purple", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-acid-biter"].loot,
@@ -539,11 +482,11 @@ then
 
       table.insert(
         data.raw.unit["bob-behemoth-acid-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-acid-spitter"].loot,
-        { item = "bob-small-alien-artifact-purple", count_min = 6, count_max = 10, probability = 1 }
+        { item = "bob-small-alien-artifact-purple", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-acid-spitter"].loot,
@@ -552,11 +495,11 @@ then
 
       table.insert(
         data.raw.unit["bob-behemoth-explosive-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-explosive-biter"].loot,
-        { item = "bob-small-alien-artifact-yellow", count_min = 6, count_max = 10, probability = 1 }
+        { item = "bob-small-alien-artifact-yellow", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-explosive-biter"].loot,
@@ -565,11 +508,11 @@ then
 
       table.insert(
         data.raw.unit["bob-behemoth-explosive-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-explosive-spitter"].loot,
-        { item = "bob-small-alien-artifact-yellow", count_min = 6, count_max = 10, probability = 1 }
+        { item = "bob-small-alien-artifact-yellow", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-explosive-spitter"].loot,
@@ -578,11 +521,11 @@ then
 
       table.insert(
         data.raw.unit["bob-behemoth-poison-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-poison-biter"].loot,
-        { item = "bob-small-alien-artifact-green", count_min = 6, count_max = 10, probability = 1 }
+        { item = "bob-small-alien-artifact-green", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-poison-biter"].loot,
@@ -591,11 +534,11 @@ then
 
       table.insert(
         data.raw.unit["bob-behemoth-poison-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-poison-spitter"].loot,
-        { item = "bob-small-alien-artifact-green", count_min = 6, count_max = 10, probability = 1 }
+        { item = "bob-small-alien-artifact-green", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-poison-spitter"].loot,
@@ -604,11 +547,11 @@ then
 
       table.insert(
         data.raw.unit["bob-behemoth-fire-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-fire-biter"].loot,
-        { item = "bob-small-alien-artifact-red", count_min = 6, count_max = 10, probability = 1 }
+        { item = "bob-small-alien-artifact-red", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-fire-biter"].loot,
@@ -617,11 +560,11 @@ then
 
       table.insert(
         data.raw.unit["bob-behemoth-fire-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-fire-spitter"].loot,
-        { item = "bob-small-alien-artifact-red", count_min = 6, count_max = 10, probability = 1 }
+        { item = "bob-small-alien-artifact-red", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-fire-spitter"].loot,
@@ -630,11 +573,11 @@ then
 
       table.insert(
         data.raw.unit["bob-leviathan-piercing-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-piercing-biter"].loot,
-        { item = "bob-alien-artifact-blue", count_min = 2, count_max = 3, probability = 1 }
+        { item = "bob-alien-artifact-blue", count_min = 2, count_max = 3 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-piercing-biter"].loot,
@@ -659,11 +602,11 @@ then
 
       table.insert(
         data.raw.unit["bob-leviathan-piercing-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-piercing-spitter"].loot,
-        { item = "bob-alien-artifact-blue", count_min = 2, count_max = 3, probability = 1 }
+        { item = "bob-alien-artifact-blue", count_min = 2, count_max = 3 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-piercing-spitter"].loot,
@@ -688,7 +631,7 @@ then
 
       table.insert(
         data.raw.unit["bob-leviathan-electric-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-electric-biter"].loot,
@@ -696,7 +639,7 @@ then
       )
       table.insert(
         data.raw.unit["bob-leviathan-electric-biter"].loot,
-        { item = "bob-alien-artifact-orange", count_min = 2, count_max = 3, probability = 1 }
+        { item = "bob-alien-artifact-orange", count_min = 2, count_max = 3 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-electric-biter"].loot,
@@ -717,7 +660,7 @@ then
 
       table.insert(
         data.raw.unit["bob-leviathan-electric-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-electric-spitter"].loot,
@@ -725,7 +668,7 @@ then
       )
       table.insert(
         data.raw.unit["bob-leviathan-electric-spitter"].loot,
-        { item = "bob-alien-artifact-orange", count_min = 2, count_max = 3, probability = 1 }
+        { item = "bob-alien-artifact-orange", count_min = 2, count_max = 3 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-electric-spitter"].loot,
@@ -746,7 +689,7 @@ then
 
       table.insert(
         data.raw.unit["bob-leviathan-acid-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-acid-biter"].loot,
@@ -758,7 +701,7 @@ then
       )
       table.insert(
         data.raw.unit["bob-leviathan-acid-biter"].loot,
-        { item = "bob-alien-artifact-purple", count_min = 2, count_max = 3, probability = 1 }
+        { item = "bob-alien-artifact-purple", count_min = 2, count_max = 3 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-acid-biter"].loot,
@@ -775,7 +718,7 @@ then
 
       table.insert(
         data.raw.unit["bob-leviathan-acid-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-acid-spitter"].loot,
@@ -787,7 +730,7 @@ then
       )
       table.insert(
         data.raw.unit["bob-leviathan-acid-spitter"].loot,
-        { item = "bob-alien-artifact-purple", count_min = 2, count_max = 3, probability = 1 }
+        { item = "bob-alien-artifact-purple", count_min = 2, count_max = 3 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-acid-spitter"].loot,
@@ -804,7 +747,7 @@ then
 
       table.insert(
         data.raw.unit["bob-leviathan-explosive-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-explosive-biter"].loot,
@@ -820,7 +763,7 @@ then
       )
       table.insert(
         data.raw.unit["bob-leviathan-explosive-biter"].loot,
-        { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 3, probability = 1 }
+        { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 3 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-explosive-biter"].loot,
@@ -833,7 +776,7 @@ then
 
       table.insert(
         data.raw.unit["bob-leviathan-explosive-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-explosive-spitter"].loot,
@@ -849,7 +792,7 @@ then
       )
       table.insert(
         data.raw.unit["bob-leviathan-explosive-spitter"].loot,
-        { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 3, probability = 1 }
+        { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 3 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-explosive-spitter"].loot,
@@ -862,7 +805,7 @@ then
 
       table.insert(
         data.raw.unit["bob-leviathan-poison-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-poison-biter"].loot,
@@ -882,7 +825,7 @@ then
       )
       table.insert(
         data.raw.unit["bob-leviathan-poison-biter"].loot,
-        { item = "bob-alien-artifact-green", count_min = 2, count_max = 3, probability = 1 }
+        { item = "bob-alien-artifact-green", count_min = 2, count_max = 3 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-poison-biter"].loot,
@@ -891,7 +834,7 @@ then
 
       table.insert(
         data.raw.unit["bob-leviathan-poison-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-poison-spitter"].loot,
@@ -911,7 +854,7 @@ then
       )
       table.insert(
         data.raw.unit["bob-leviathan-poison-spitter"].loot,
-        { item = "bob-alien-artifact-green", count_min = 2, count_max = 3, probability = 1 }
+        { item = "bob-alien-artifact-green", count_min = 2, count_max = 3 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-poison-spitter"].loot,
@@ -920,7 +863,7 @@ then
 
       table.insert(
         data.raw.unit["bob-leviathan-fire-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-fire-biter"].loot,
@@ -944,12 +887,12 @@ then
       )
       table.insert(
         data.raw.unit["bob-leviathan-fire-biter"].loot,
-        { item = "bob-alien-artifact-red", count_min = 2, count_max = 3, probability = 1 }
+        { item = "bob-alien-artifact-red", count_min = 2, count_max = 3 }
       )
 
       table.insert(
         data.raw.unit["bob-leviathan-fire-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-fire-spitter"].loot,
@@ -973,417 +916,368 @@ then
       )
       table.insert(
         data.raw.unit["bob-leviathan-fire-spitter"].loot,
-        { item = "bob-alien-artifact-red", count_min = 2, count_max = 3, probability = 1 }
+        { item = "bob-alien-artifact-red", count_min = 2, count_max = 3 }
       )
     else
       table.insert(
         data.raw.unit["behemoth-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 10, count_max = 16, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 8, count_max = 12 }
       )
       table.insert(
         data.raw.unit["behemoth-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 10, count_max = 16, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 8, count_max = 12 }
       )
 
       table.insert(
         data.raw.unit["bob-leviathan-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 3, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 3, count_max = 10 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 3, count_max = 10, probability = 1 }
-      )
-
-      table.insert(
-        data.raw.unit["bob-small-piercing-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-piercing-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-electric-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-electric-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-acid-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-acid-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-explosive-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-explosive-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-poison-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-poison-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-fire-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
-      )
-      table.insert(
-        data.raw.unit["bob-small-fire-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
+        { item = "bob-alien-artifact", count_min = 3, count_max = 10 }
       )
 
       table.insert(
         data.raw.unit["bob-medium-piercing-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-piercing-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-electric-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-electric-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-acid-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-acid-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-explosive-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-explosive-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-poison-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-poison-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-fire-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
       )
       table.insert(
         data.raw.unit["bob-medium-fire-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 1, probability = 0.5 }
       )
 
       table.insert(
         data.raw.unit["bob-big-piercing-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-piercing-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-electric-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-electric-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-acid-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-acid-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-explosive-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-explosive-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-poison-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-poison-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-fire-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
       )
       table.insert(
         data.raw.unit["bob-big-fire-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 1, count_max = 3, probability = 0.75 }
       )
 
       table.insert(
         data.raw.unit["bob-huge-piercing-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-piercing-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-electric-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-electric-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-acid-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-acid-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-explosive-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-explosive-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-poison-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-poison-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-fire-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 4 }
       )
       table.insert(
         data.raw.unit["bob-huge-fire-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 2, count_max = 5, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 2, count_max = 4 }
       )
 
       table.insert(
         data.raw.unit["bob-giant-piercing-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-piercing-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-electric-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-electric-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-acid-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-acid-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-explosive-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-explosive-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-poison-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-poison-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-fire-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 3, count_max = 5 }
       )
       table.insert(
         data.raw.unit["bob-giant-fire-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 3, count_max = 5 }
       )
 
       table.insert(
         data.raw.unit["bob-titan-piercing-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-piercing-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-electric-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-electric-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-acid-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-acid-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-explosive-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-explosive-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-poison-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-poison-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-fire-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 5, count_max = 8 }
       )
       table.insert(
         data.raw.unit["bob-titan-fire-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 5, count_max = 11, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 5, count_max = 8 }
       )
 
       table.insert(
         data.raw.unit["bob-behemoth-piercing-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 10, count_max = 16, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 8, count_max = 16 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-piercing-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 10, count_max = 16, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 8, count_max = 12 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-electric-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 10, count_max = 16, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 8, count_max = 12 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-electric-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 10, count_max = 16, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 8, count_max = 12 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-acid-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 10, count_max = 16, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 8, count_max = 12 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-acid-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 10, count_max = 16, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 8, count_max = 12 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-explosive-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 10, count_max = 16, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 8, count_max = 12 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-explosive-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 10, count_max = 16, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 8, count_max = 12 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-poison-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 10, count_max = 16, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 8, count_max = 12 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-poison-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 10, count_max = 16, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 8, count_max = 12 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-fire-biter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 10, count_max = 16, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 8, count_max = 12 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-fire-spitter"].loot,
-        { item = "bob-small-alien-artifact", count_min = 10, count_max = 16, probability = 1 }
+        { item = "bob-small-alien-artifact", count_min = 8, count_max = 12 }
       )
 
       table.insert(
         data.raw.unit["bob-leviathan-piercing-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 3, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 3, count_max = 10 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-piercing-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 3, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 3, count_max = 10 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-electric-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 3, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 3, count_max = 10 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-electric-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 3, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 3, count_max = 10 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-acid-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 3, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 3, count_max = 10 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-acid-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 3, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 3, count_max = 10 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-explosive-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 3, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 3, count_max = 10 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-explosive-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 3, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 3, count_max = 10 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-poison-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 3, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 3, count_max = 10 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-poison-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 3, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 3, count_max = 10 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-fire-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 3, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 3, count_max = 10 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-fire-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 3, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 3, count_max = 10 }
       )
     end
   else
@@ -1397,17 +1291,17 @@ then
     )
     table.insert(
       data.raw.unit["behemoth-biter"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
     )
     table.insert(
       data.raw.unit["behemoth-spitter"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
     )
 
     if settings.startup["bobmods-enemies-enablenewartifacts"].value == true then
       table.insert(
         data.raw.unit["bob-leviathan-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 2, count_max = 3, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 2, count_max = 3 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-biter"].loot,
@@ -1436,7 +1330,7 @@ then
 
       table.insert(
         data.raw.unit["bob-leviathan-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 2, count_max = 3, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 2, count_max = 3 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-spitter"].loot,
@@ -1473,19 +1367,19 @@ then
       )
       table.insert(
         data.raw.unit["bob-behemoth-piercing-biter"].loot,
-        { item = "bob-alien-artifact-blue", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact-blue", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-piercing-spitter"].loot,
-        { item = "bob-alien-artifact-blue", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact-blue", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-piercing-biter"].loot,
-        { item = "bob-alien-artifact-blue", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact-blue", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-piercing-spitter"].loot,
-        { item = "bob-alien-artifact-blue", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact-blue", count_min = 5, count_max = 9 }
       )
 
       table.insert(
@@ -1498,19 +1392,19 @@ then
       )
       table.insert(
         data.raw.unit["bob-behemoth-electric-biter"].loot,
-        { item = "bob-alien-artifact-orange", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact-orange", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-electric-spitter"].loot,
-        { item = "bob-alien-artifact-orange", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact-orange", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-electric-biter"].loot,
-        { item = "bob-alien-artifact-orange", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact-orange", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-electric-spitter"].loot,
-        { item = "bob-alien-artifact-orange", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact-orange", count_min = 5, count_max = 9 }
       )
 
       table.insert(
@@ -1523,19 +1417,19 @@ then
       )
       table.insert(
         data.raw.unit["bob-behemoth-acid-biter"].loot,
-        { item = "bob-alien-artifact-purple", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact-purple", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-acid-spitter"].loot,
-        { item = "bob-alien-artifact-purple", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact-purple", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-acid-biter"].loot,
-        { item = "bob-alien-artifact-purple", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact-purple", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-acid-spitter"].loot,
-        { item = "bob-alien-artifact-purple", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact-purple", count_min = 5, count_max = 9 }
       )
 
       table.insert(
@@ -1548,19 +1442,19 @@ then
       )
       table.insert(
         data.raw.unit["bob-behemoth-explosive-biter"].loot,
-        { item = "bob-alien-artifact-yellow", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact-yellow", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-explosive-spitter"].loot,
-        { item = "bob-alien-artifact-yellow", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact-yellow", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-explosive-biter"].loot,
-        { item = "bob-alien-artifact-yellow", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact-yellow", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-explosive-spitter"].loot,
-        { item = "bob-alien-artifact-yellow", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact-yellow", count_min = 5, count_max = 9 }
       )
 
       table.insert(
@@ -1573,19 +1467,19 @@ then
       )
       table.insert(
         data.raw.unit["bob-behemoth-poison-biter"].loot,
-        { item = "bob-alien-artifact-green", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact-green", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-poison-spitter"].loot,
-        { item = "bob-alien-artifact-green", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact-green", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-poison-biter"].loot,
-        { item = "bob-alien-artifact-green", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact-green", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-poison-spitter"].loot,
-        { item = "bob-alien-artifact-green", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact-green", count_min = 5, count_max = 9 }
       )
 
       table.insert(
@@ -1598,28 +1492,28 @@ then
       )
       table.insert(
         data.raw.unit["bob-behemoth-fire-biter"].loot,
-        { item = "bob-alien-artifact-red", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact-red", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-fire-spitter"].loot,
-        { item = "bob-alien-artifact-red", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact-red", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-fire-biter"].loot,
-        { item = "bob-alien-artifact-red", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact-red", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-fire-spitter"].loot,
-        { item = "bob-alien-artifact-red", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact-red", count_min = 5, count_max = 9 }
       )
     else
       table.insert(
         data.raw.unit["bob-leviathan-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 5, count_max = 9 }
       )
 
       table.insert(
@@ -1632,19 +1526,19 @@ then
       )
       table.insert(
         data.raw.unit["bob-behemoth-piercing-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-piercing-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-piercing-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-piercing-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 5, count_max = 9 }
       )
 
       table.insert(
@@ -1657,19 +1551,19 @@ then
       )
       table.insert(
         data.raw.unit["bob-behemoth-electric-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-electric-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-electric-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-electric-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 5, count_max = 9 }
       )
 
       table.insert(
@@ -1682,19 +1576,19 @@ then
       )
       table.insert(
         data.raw.unit["bob-behemoth-acid-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-acid-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-acid-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-acid-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 5, count_max = 9 }
       )
 
       table.insert(
@@ -1707,19 +1601,19 @@ then
       )
       table.insert(
         data.raw.unit["bob-behemoth-explosive-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-explosive-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-explosive-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-explosive-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 5, count_max = 9 }
       )
 
       table.insert(
@@ -1732,19 +1626,19 @@ then
       )
       table.insert(
         data.raw.unit["bob-behemoth-poison-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-poison-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-poison-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-poison-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 5, count_max = 9 }
       )
 
       table.insert(
@@ -1757,19 +1651,19 @@ then
       )
       table.insert(
         data.raw.unit["bob-behemoth-fire-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-behemoth-fire-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-fire-biter"].loot,
-        { item = "bob-alien-artifact", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 5, count_max = 9 }
       )
       table.insert(
         data.raw.unit["bob-leviathan-fire-spitter"].loot,
-        { item = "bob-alien-artifact", count_min = 5, count_max = 9, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 5, count_max = 9 }
       )
     end
   end
@@ -1783,7 +1677,7 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
   end
   table.insert(
     data.raw["unit-spawner"]["bob-0-biter-spawner"].loot,
-    { item = "bob-alien-artifact", count_min = 5, count_max = 15, probability = 1 }
+    { item = "bob-alien-artifact", count_min = 5, count_max = 15 }
   )
 
   if data.raw["unit-spawner"]["bob-0-spitter-spawner"].loot == nil then
@@ -1791,446 +1685,446 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
   end
   table.insert(
     data.raw["unit-spawner"]["bob-0-spitter-spawner"].loot,
-    { item = "bob-alien-artifact", count_min = 5, count_max = 15, probability = 1 }
+    { item = "bob-alien-artifact", count_min = 5, count_max = 15 }
   )
 
   table.insert(
     data.raw["unit-spawner"]["bob-biter-spawner"].loot,
-    { item = "bob-alien-artifact", count_min = 8, count_max = 22, probability = 1 }
+    { item = "bob-alien-artifact", count_min = 8, count_max = 22 }
   )
   table.insert(
     data.raw["unit-spawner"]["bob-spitter-spawner"].loot,
-    { item = "bob-alien-artifact", count_min = 8, count_max = 22, probability = 1 }
+    { item = "bob-alien-artifact", count_min = 8, count_max = 22 }
   )
 
   if settings.startup["bobmods-enemies-enablenewartifacts"].value == true then
     table.insert(
       data.raw["unit-spawner"]["bob-0-piercing-biter-spawner"].loot,
-      { item = "bob-alien-artifact-blue", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact-blue", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-piercing-spitter-spawner"].loot,
-      { item = "bob-alien-artifact-blue", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact-blue", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-piercing-biter-spawner"].loot,
-      { item = "bob-alien-artifact-blue", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact-blue", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-piercing-spitter-spawner"].loot,
-      { item = "bob-alien-artifact-blue", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact-blue", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-electric-biter-spawner"].loot,
-      { item = "bob-alien-artifact-orange", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact-orange", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-electric-spitter-spawner"].loot,
-      { item = "bob-alien-artifact-orange", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact-orange", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-electric-biter-spawner"].loot,
-      { item = "bob-alien-artifact-orange", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact-orange", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-electric-spitter-spawner"].loot,
-      { item = "bob-alien-artifact-orange", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact-orange", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-acid-biter-spawner"].loot,
-      { item = "bob-alien-artifact-purple", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact-purple", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-acid-spitter-spawner"].loot,
-      { item = "bob-alien-artifact-purple", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact-purple", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-acid-biter-spawner"].loot,
-      { item = "bob-alien-artifact-purple", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact-purple", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-acid-spitter-spawner"].loot,
-      { item = "bob-alien-artifact-purple", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact-purple", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-explosive-biter-spawner"].loot,
-      { item = "bob-alien-artifact-yellow", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact-yellow", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-explosive-spitter-spawner"].loot,
-      { item = "bob-alien-artifact-yellow", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact-yellow", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-explosive-biter-spawner"].loot,
-      { item = "bob-alien-artifact-yellow", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact-yellow", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-explosive-spitter-spawner"].loot,
-      { item = "bob-alien-artifact-yellow", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact-yellow", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-poison-biter-spawner"].loot,
-      { item = "bob-alien-artifact-green", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact-green", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-poison-spitter-spawner"].loot,
-      { item = "bob-alien-artifact-green", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact-green", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-poison-biter-spawner"].loot,
-      { item = "bob-alien-artifact-green", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact-green", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-poison-spitter-spawner"].loot,
-      { item = "bob-alien-artifact-green", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact-green", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-fire-biter-spawner"].loot,
-      { item = "bob-alien-artifact-red", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact-red", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-fire-spitter-spawner"].loot,
-      { item = "bob-alien-artifact-red", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact-red", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-fire-biter-spawner"].loot,
-      { item = "bob-alien-artifact-red", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact-red", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-fire-spitter-spawner"].loot,
-      { item = "bob-alien-artifact-red", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact-red", count_min = 8, count_max = 22 }
     )
 
     if settings.startup["bobmods-enemies-superspawner"].value == true then
       table.insert(
         data.raw["unit-spawner"]["bob-super-spawner"].loot,
-        { item = "bob-alien-artifact", count_min = 20, count_max = 36, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 20, count_max = 36 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-super-spawner"].loot,
-        { item = "bob-alien-artifact-blue", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-blue", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-super-spawner"].loot,
-        { item = "bob-alien-artifact-orange", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-orange", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-super-spawner"].loot,
-        { item = "bob-alien-artifact-purple", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-purple", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-super-spawner"].loot,
-        { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-super-spawner"].loot,
-        { item = "bob-alien-artifact-green", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-green", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-super-spawner"].loot,
-        { item = "bob-alien-artifact-red", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-red", count_min = 2, count_max = 10 }
       )
 
       table.insert(
         data.raw["unit-spawner"]["bob-piercing-super-spawner"].loot,
-        { item = "bob-alien-artifact", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-piercing-super-spawner"].loot,
-        { item = "bob-alien-artifact-blue", count_min = 20, count_max = 36, probability = 1 }
+        { item = "bob-alien-artifact-blue", count_min = 20, count_max = 36 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-piercing-super-spawner"].loot,
-        { item = "bob-alien-artifact-orange", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-orange", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-piercing-super-spawner"].loot,
-        { item = "bob-alien-artifact-purple", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-purple", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-piercing-super-spawner"].loot,
-        { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-piercing-super-spawner"].loot,
-        { item = "bob-alien-artifact-green", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-green", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-piercing-super-spawner"].loot,
-        { item = "bob-alien-artifact-red", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-red", count_min = 2, count_max = 10 }
       )
 
       table.insert(
         data.raw["unit-spawner"]["bob-electric-super-spawner"].loot,
-        { item = "bob-alien-artifact", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-electric-super-spawner"].loot,
-        { item = "bob-alien-artifact-blue", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-blue", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-electric-super-spawner"].loot,
-        { item = "bob-alien-artifact-orange", count_min = 20, count_max = 36, probability = 1 }
+        { item = "bob-alien-artifact-orange", count_min = 20, count_max = 36 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-electric-super-spawner"].loot,
-        { item = "bob-alien-artifact-purple", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-purple", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-electric-super-spawner"].loot,
-        { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-electric-super-spawner"].loot,
-        { item = "bob-alien-artifact-green", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-green", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-electric-super-spawner"].loot,
-        { item = "bob-alien-artifact-red", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-red", count_min = 2, count_max = 10 }
       )
 
       table.insert(
         data.raw["unit-spawner"]["bob-acid-super-spawner"].loot,
-        { item = "bob-alien-artifact", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-acid-super-spawner"].loot,
-        { item = "bob-alien-artifact-blue", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-blue", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-acid-super-spawner"].loot,
-        { item = "bob-alien-artifact-orange", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-orange", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-acid-super-spawner"].loot,
-        { item = "bob-alien-artifact-purple", count_min = 20, count_max = 36, probability = 1 }
+        { item = "bob-alien-artifact-purple", count_min = 20, count_max = 36 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-acid-super-spawner"].loot,
-        { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-acid-super-spawner"].loot,
-        { item = "bob-alien-artifact-green", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-green", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-acid-super-spawner"].loot,
-        { item = "bob-alien-artifact-red", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-red", count_min = 2, count_max = 10 }
       )
 
       table.insert(
         data.raw["unit-spawner"]["bob-explosive-super-spawner"].loot,
-        { item = "bob-alien-artifact", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-explosive-super-spawner"].loot,
-        { item = "bob-alien-artifact-blue", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-blue", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-explosive-super-spawner"].loot,
-        { item = "bob-alien-artifact-orange", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-orange", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-explosive-super-spawner"].loot,
-        { item = "bob-alien-artifact-purple", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-purple", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-explosive-super-spawner"].loot,
-        { item = "bob-alien-artifact-yellow", count_min = 20, count_max = 36, probability = 1 }
+        { item = "bob-alien-artifact-yellow", count_min = 20, count_max = 36 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-explosive-super-spawner"].loot,
-        { item = "bob-alien-artifact-green", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-green", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-explosive-super-spawner"].loot,
-        { item = "bob-alien-artifact-red", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-red", count_min = 2, count_max = 10 }
       )
 
       table.insert(
         data.raw["unit-spawner"]["bob-poison-super-spawner"].loot,
-        { item = "bob-alien-artifact", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-poison-super-spawner"].loot,
-        { item = "bob-alien-artifact-blue", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-blue", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-poison-super-spawner"].loot,
-        { item = "bob-alien-artifact-orange", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-orange", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-poison-super-spawner"].loot,
-        { item = "bob-alien-artifact-purple", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-purple", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-poison-super-spawner"].loot,
-        { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-poison-super-spawner"].loot,
-        { item = "bob-alien-artifact-green", count_min = 20, count_max = 36, probability = 1 }
+        { item = "bob-alien-artifact-green", count_min = 20, count_max = 36 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-poison-super-spawner"].loot,
-        { item = "bob-alien-artifact-red", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-red", count_min = 2, count_max = 10 }
       )
 
       table.insert(
         data.raw["unit-spawner"]["bob-fire-super-spawner"].loot,
-        { item = "bob-alien-artifact", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-fire-super-spawner"].loot,
-        { item = "bob-alien-artifact-blue", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-blue", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-fire-super-spawner"].loot,
-        { item = "bob-alien-artifact-orange", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-orange", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-fire-super-spawner"].loot,
-        { item = "bob-alien-artifact-purple", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-purple", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-fire-super-spawner"].loot,
-        { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-fire-super-spawner"].loot,
-        { item = "bob-alien-artifact-green", count_min = 2, count_max = 10, probability = 1 }
+        { item = "bob-alien-artifact-green", count_min = 2, count_max = 10 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-fire-super-spawner"].loot,
-        { item = "bob-alien-artifact-red", count_min = 20, count_max = 36, probability = 1 }
+        { item = "bob-alien-artifact-red", count_min = 20, count_max = 36 }
       )
     end
   else
     table.insert(
       data.raw["unit-spawner"]["bob-0-piercing-biter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-piercing-spitter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-piercing-biter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-piercing-spitter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-electric-biter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-electric-spitter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-electric-biter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-electric-spitter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-acid-biter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-acid-spitter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-acid-biter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-acid-spitter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-explosive-biter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-explosive-spitter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-explosive-biter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-explosive-spitter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-poison-biter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-poison-spitter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-poison-biter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-poison-spitter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-fire-biter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-0-fire-spitter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 15 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-fire-biter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 8, count_max = 22 }
     )
     table.insert(
       data.raw["unit-spawner"]["bob-fire-spitter-spawner"].loot,
-      { item = "bob-alien-artifact", count_min = 8, count_max = 22, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 8, count_max = 22 }
     )
 
     if settings.startup["bobmods-enemies-superspawner"].value == true then
       table.insert(
         data.raw["unit-spawner"]["bob-super-spawner"].loot,
-        { item = "bob-alien-artifact", count_min = 32, count_max = 84, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 32, count_max = 84 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-piercing-super-spawner"].loot,
-        { item = "bob-alien-artifact", count_min = 32, count_max = 84, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 32, count_max = 84 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-electric-super-spawner"].loot,
-        { item = "bob-alien-artifact", count_min = 32, count_max = 84, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 32, count_max = 84 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-acid-super-spawner"].loot,
-        { item = "bob-alien-artifact", count_min = 32, count_max = 84, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 32, count_max = 84 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-explosive-super-spawner"].loot,
-        { item = "bob-alien-artifact", count_min = 32, count_max = 84, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 32, count_max = 84 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-poison-super-spawner"].loot,
-        { item = "bob-alien-artifact", count_min = 32, count_max = 84, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 32, count_max = 84 }
       )
       table.insert(
         data.raw["unit-spawner"]["bob-fire-super-spawner"].loot,
-        { item = "bob-alien-artifact", count_min = 32, count_max = 84, probability = 1 }
+        { item = "bob-alien-artifact", count_min = 32, count_max = 84 }
       )
     end
   end
@@ -2240,7 +2134,7 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
   end
   table.insert(
     data.raw.turret["small-worm-turret"].loot,
-    { item = "bob-alien-artifact", count_min = 1, count_max = 3, probability = 1 }
+    { item = "bob-alien-artifact", count_min = 1, count_max = 3 }
   )
 
   if data.raw.turret["medium-worm-turret"].loot == nil then
@@ -2248,7 +2142,7 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
   end
   table.insert(
     data.raw.turret["medium-worm-turret"].loot,
-    { item = "bob-alien-artifact", count_min = 2, count_max = 4, probability = 1 }
+    { item = "bob-alien-artifact", count_min = 2, count_max = 4 }
   )
 
   if data.raw.turret["big-worm-turret"].loot == nil then
@@ -2256,22 +2150,22 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
   end
   table.insert(
     data.raw.turret["big-worm-turret"].loot,
-    { item = "bob-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+    { item = "bob-alien-artifact", count_min = 3, count_max = 6 }
   )
 
   table.insert(
     data.raw.turret["bob-huge-worm-turret"].loot,
-    { item = "bob-alien-artifact", count_min = 4, count_max = 8, probability = 1 }
+    { item = "bob-alien-artifact", count_min = 4, count_max = 8 }
   )
 
   table.insert(
     data.raw.turret["bob-giant-worm-turret"].loot,
-    { item = "bob-alien-artifact", count_min = 5, count_max = 10, probability = 1 }
+    { item = "bob-alien-artifact", count_min = 5, count_max = 10 }
   )
 
   table.insert(
     data.raw.turret["bob-titan-worm-turret"].loot,
-    { item = "bob-alien-artifact", count_min = 6, count_max = 12, probability = 1 }
+    { item = "bob-alien-artifact", count_min = 6, count_max = 12 }
   )
 
   if data.raw.turret["behemoth-worm-turret"].loot == nil then
@@ -2281,7 +2175,7 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
   if settings.startup["bobmods-enemies-enablenewartifacts"].value == true then
     table.insert(
       data.raw.turret["behemoth-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 8, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 8 }
     )
     table.insert(
       data.raw.turret["behemoth-worm-turret"].loot,
@@ -2310,7 +2204,7 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
 
     table.insert(
       data.raw.turret["bob-leviathan-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 8, count_max = 14, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 8, count_max = 14 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-worm-turret"].loot,
@@ -2343,56 +2237,56 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
     )
     table.insert(
       data.raw.turret["bob-small-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact-blue", count_min = 1, count_max = 2, probability = 1 }
+      { item = "bob-alien-artifact-blue", count_min = 1, count_max = 2 }
     )
     table.insert(
       data.raw.turret["bob-medium-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 1, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 1 }
     )
     table.insert(
       data.raw.turret["bob-medium-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact-blue", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact-blue", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-big-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
     )
     table.insert(
       data.raw.turret["bob-big-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact-blue", count_min = 2, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact-blue", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-huge-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-huge-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact-blue", count_min = 2, count_max = 6, probability = 1 }
+      { item = "bob-alien-artifact-blue", count_min = 2, count_max = 6 }
     )
     table.insert(
       data.raw.turret["bob-giant-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-giant-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact-blue", count_min = 3, count_max = 7, probability = 1 }
+      { item = "bob-alien-artifact-blue", count_min = 3, count_max = 7 }
     )
     table.insert(
       data.raw.turret["bob-titan-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-titan-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact-blue", count_min = 3, count_max = 9, probability = 1 }
+      { item = "bob-alien-artifact-blue", count_min = 3, count_max = 9 }
     )
 
     table.insert(
       data.raw.turret["bob-behemoth-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 6, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 6 }
     )
     table.insert(
       data.raw.turret["bob-behemoth-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact-blue", count_min = 4, count_max = 10, probability = 1 }
+      { item = "bob-alien-artifact-blue", count_min = 4, count_max = 10 }
     )
     table.insert(
       data.raw.turret["bob-behemoth-piercing-worm-turret"].loot,
@@ -2401,19 +2295,19 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
 
     table.insert(
       data.raw.turret["bob-leviathan-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 8, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 8 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact-blue", count_min = 5, count_max = 11, probability = 1 }
+      { item = "bob-alien-artifact-blue", count_min = 5, count_max = 11 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact-yellow", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact-yellow", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact-red", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact-red", count_min = 1, count_max = 3 }
     )
 
     table.insert(
@@ -2422,56 +2316,56 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
     )
     table.insert(
       data.raw.turret["bob-small-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact-orange", count_min = 1, count_max = 2, probability = 1 }
+      { item = "bob-alien-artifact-orange", count_min = 1, count_max = 2 }
     )
     table.insert(
       data.raw.turret["bob-medium-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 1, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 1 }
     )
     table.insert(
       data.raw.turret["bob-medium-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact-orange", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact-orange", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-big-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
     )
     table.insert(
       data.raw.turret["bob-big-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact-orange", count_min = 2, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact-orange", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-huge-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-huge-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact-orange", count_min = 2, count_max = 6, probability = 1 }
+      { item = "bob-alien-artifact-orange", count_min = 2, count_max = 6 }
     )
     table.insert(
       data.raw.turret["bob-giant-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-giant-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact-orange", count_min = 3, count_max = 7, probability = 1 }
+      { item = "bob-alien-artifact-orange", count_min = 3, count_max = 7 }
     )
     table.insert(
       data.raw.turret["bob-titan-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-titan-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact-orange", count_min = 3, count_max = 9, probability = 1 }
+      { item = "bob-alien-artifact-orange", count_min = 3, count_max = 9 }
     )
 
     table.insert(
       data.raw.turret["bob-behemoth-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 6, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 6 }
     )
     table.insert(
       data.raw.turret["bob-behemoth-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact-orange", count_min = 4, count_max = 10, probability = 1 }
+      { item = "bob-alien-artifact-orange", count_min = 4, count_max = 10 }
     )
     table.insert(
       data.raw.turret["bob-behemoth-electric-worm-turret"].loot,
@@ -2480,19 +2374,19 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
 
     table.insert(
       data.raw.turret["bob-leviathan-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 8, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 8 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact-orange", count_min = 5, count_max = 11, probability = 1 }
+      { item = "bob-alien-artifact-orange", count_min = 5, count_max = 11 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact-purple", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact-purple", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact-green", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact-green", count_min = 1, count_max = 3 }
     )
 
     table.insert(
@@ -2501,56 +2395,56 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
     )
     table.insert(
       data.raw.turret["bob-small-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact-purple", count_min = 1, count_max = 2, probability = 1 }
+      { item = "bob-alien-artifact-purple", count_min = 1, count_max = 2 }
     )
     table.insert(
       data.raw.turret["bob-medium-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 1, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 1 }
     )
     table.insert(
       data.raw.turret["bob-medium-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact-purple", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact-purple", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-big-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
     )
     table.insert(
       data.raw.turret["bob-big-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact-purple", count_min = 2, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact-purple", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-huge-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-huge-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact-purple", count_min = 2, count_max = 6, probability = 1 }
+      { item = "bob-alien-artifact-purple", count_min = 2, count_max = 6 }
     )
     table.insert(
       data.raw.turret["bob-giant-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-giant-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact-purple", count_min = 3, count_max = 7, probability = 1 }
+      { item = "bob-alien-artifact-purple", count_min = 3, count_max = 7 }
     )
     table.insert(
       data.raw.turret["bob-titan-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-titan-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact-purple", count_min = 3, count_max = 9, probability = 1 }
+      { item = "bob-alien-artifact-purple", count_min = 3, count_max = 9 }
     )
 
     table.insert(
       data.raw.turret["bob-behemoth-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 6, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 6 }
     )
     table.insert(
       data.raw.turret["bob-behemoth-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact-purple", count_min = 4, count_max = 10, probability = 1 }
+      { item = "bob-alien-artifact-purple", count_min = 4, count_max = 10 }
     )
     table.insert(
       data.raw.turret["bob-behemoth-acid-worm-turret"].loot,
@@ -2559,19 +2453,19 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
 
     table.insert(
       data.raw.turret["bob-leviathan-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 8, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 8 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact-purple", count_min = 5, count_max = 11, probability = 1 }
+      { item = "bob-alien-artifact-purple", count_min = 5, count_max = 11 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact-red", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact-red", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact-orange", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact-orange", count_min = 1, count_max = 3 }
     )
 
     table.insert(
@@ -2580,56 +2474,56 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
     )
     table.insert(
       data.raw.turret["bob-small-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact-yellow", count_min = 1, count_max = 2, probability = 1 }
+      { item = "bob-alien-artifact-yellow", count_min = 1, count_max = 2 }
     )
     table.insert(
       data.raw.turret["bob-medium-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 1, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 1 }
     )
     table.insert(
       data.raw.turret["bob-medium-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact-yellow", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact-yellow", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-big-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
     )
     table.insert(
       data.raw.turret["bob-big-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-huge-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-huge-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 6, probability = 1 }
+      { item = "bob-alien-artifact-yellow", count_min = 2, count_max = 6 }
     )
     table.insert(
       data.raw.turret["bob-giant-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-giant-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact-yellow", count_min = 3, count_max = 7, probability = 1 }
+      { item = "bob-alien-artifact-yellow", count_min = 3, count_max = 7 }
     )
     table.insert(
       data.raw.turret["bob-titan-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-titan-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact-yellow", count_min = 3, count_max = 9, probability = 1 }
+      { item = "bob-alien-artifact-yellow", count_min = 3, count_max = 9 }
     )
 
     table.insert(
       data.raw.turret["bob-behemoth-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 6, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 6 }
     )
     table.insert(
       data.raw.turret["bob-behemoth-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact-yellow", count_min = 4, count_max = 10, probability = 1 }
+      { item = "bob-alien-artifact-yellow", count_min = 4, count_max = 10 }
     )
     table.insert(
       data.raw.turret["bob-behemoth-explosive-worm-turret"].loot,
@@ -2638,19 +2532,19 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
 
     table.insert(
       data.raw.turret["bob-leviathan-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 8, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 8 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact-yellow", count_min = 5, count_max = 11, probability = 1 }
+      { item = "bob-alien-artifact-yellow", count_min = 5, count_max = 11 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact-green", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact-green", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact-blue", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact-blue", count_min = 1, count_max = 3 }
     )
 
     table.insert(
@@ -2659,56 +2553,56 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
     )
     table.insert(
       data.raw.turret["bob-small-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact-green", count_min = 1, count_max = 2, probability = 1 }
+      { item = "bob-alien-artifact-green", count_min = 1, count_max = 2 }
     )
     table.insert(
       data.raw.turret["bob-medium-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 1, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 1 }
     )
     table.insert(
       data.raw.turret["bob-medium-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact-green", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact-green", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-big-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
     )
     table.insert(
       data.raw.turret["bob-big-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact-green", count_min = 2, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact-green", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-huge-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-huge-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact-green", count_min = 2, count_max = 6, probability = 1 }
+      { item = "bob-alien-artifact-green", count_min = 2, count_max = 6 }
     )
     table.insert(
       data.raw.turret["bob-giant-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-giant-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact-green", count_min = 3, count_max = 7, probability = 1 }
+      { item = "bob-alien-artifact-green", count_min = 3, count_max = 7 }
     )
     table.insert(
       data.raw.turret["bob-titan-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-titan-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact-green", count_min = 3, count_max = 9, probability = 1 }
+      { item = "bob-alien-artifact-green", count_min = 3, count_max = 9 }
     )
 
     table.insert(
       data.raw.turret["bob-behemoth-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 6, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 6 }
     )
     table.insert(
       data.raw.turret["bob-behemoth-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact-green", count_min = 4, count_max = 10, probability = 1 }
+      { item = "bob-alien-artifact-green", count_min = 4, count_max = 10 }
     )
     table.insert(
       data.raw.turret["bob-behemoth-poison-worm-turret"].loot,
@@ -2717,19 +2611,19 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
 
     table.insert(
       data.raw.turret["bob-leviathan-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 8, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 8 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact-green", count_min = 5, count_max = 11, probability = 1 }
+      { item = "bob-alien-artifact-green", count_min = 5, count_max = 11 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact-orange", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact-orange", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact-yellow", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact-yellow", count_min = 1, count_max = 3 }
     )
 
     table.insert(
@@ -2738,56 +2632,56 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
     )
     table.insert(
       data.raw.turret["bob-small-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact-red", count_min = 1, count_max = 2, probability = 1 }
+      { item = "bob-alien-artifact-red", count_min = 1, count_max = 2 }
     )
     table.insert(
       data.raw.turret["bob-medium-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 1, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 1 }
     )
     table.insert(
       data.raw.turret["bob-medium-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact-red", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact-red", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-big-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 2, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 2 }
     )
     table.insert(
       data.raw.turret["bob-big-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact-red", count_min = 2, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact-red", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-huge-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-huge-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact-red", count_min = 2, count_max = 6, probability = 1 }
+      { item = "bob-alien-artifact-red", count_min = 2, count_max = 6 }
     )
     table.insert(
       data.raw.turret["bob-giant-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-giant-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact-red", count_min = 3, count_max = 7, probability = 1 }
+      { item = "bob-alien-artifact-red", count_min = 3, count_max = 7 }
     )
     table.insert(
       data.raw.turret["bob-titan-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-titan-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact-red", count_min = 3, count_max = 9, probability = 1 }
+      { item = "bob-alien-artifact-red", count_min = 3, count_max = 9 }
     )
 
     table.insert(
       data.raw.turret["bob-behemoth-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 6, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 6 }
     )
     table.insert(
       data.raw.turret["bob-behemoth-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact-red", count_min = 4, count_max = 10, probability = 1 }
+      { item = "bob-alien-artifact-red", count_min = 4, count_max = 10 }
     )
     table.insert(
       data.raw.turret["bob-behemoth-fire-worm-turret"].loot,
@@ -2796,227 +2690,227 @@ if settings.startup["bobmods-enemies-enableartifacts"].value == true then
 
     table.insert(
       data.raw.turret["bob-leviathan-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 8, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 8 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact-red", count_min = 5, count_max = 11, probability = 1 }
+      { item = "bob-alien-artifact-red", count_min = 5, count_max = 11 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact-blue", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact-blue", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact-purple", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact-purple", count_min = 1, count_max = 3 }
     )
   else
     table.insert(
       data.raw.turret["behemoth-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 9, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 9, count_max = 15 }
     )
 
     table.insert(
       data.raw.turret["bob-leviathan-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 14, count_max = 20, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 14, count_max = 20 }
     )
 
     table.insert(
       data.raw.turret["bob-small-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-medium-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-big-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 3, count_max = 6 }
     )
     table.insert(
       data.raw.turret["bob-huge-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 4, count_max = 8, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 4, count_max = 8 }
     )
     table.insert(
       data.raw.turret["bob-giant-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 10, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 10 }
     )
     table.insert(
       data.raw.turret["bob-titan-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 6, count_max = 12, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 6, count_max = 12 }
     )
     table.insert(
       data.raw.turret["bob-behemoth-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 9, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 9, count_max = 15 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-piercing-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 14, count_max = 20, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 14, count_max = 20 }
     )
 
     table.insert(
       data.raw.turret["bob-small-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-medium-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-big-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 3, count_max = 6 }
     )
     table.insert(
       data.raw.turret["bob-huge-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 4, count_max = 8, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 4, count_max = 8 }
     )
     table.insert(
       data.raw.turret["bob-giant-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 10, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 10 }
     )
     table.insert(
       data.raw.turret["bob-titan-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 6, count_max = 12, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 6, count_max = 12 }
     )
     table.insert(
       data.raw.turret["bob-behemoth-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 9, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 9, count_max = 15 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-electric-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 14, count_max = 20, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 14, count_max = 20 }
     )
 
     table.insert(
       data.raw.turret["bob-small-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-medium-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-big-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 3, count_max = 6 }
     )
     table.insert(
       data.raw.turret["bob-huge-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 4, count_max = 8, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 4, count_max = 8 }
     )
     table.insert(
       data.raw.turret["bob-giant-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 10, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 10 }
     )
     table.insert(
       data.raw.turret["bob-titan-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 6, count_max = 12, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 6, count_max = 12 }
     )
     table.insert(
       data.raw.turret["bob-behemoth-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 9, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 9, count_max = 15 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-acid-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 14, count_max = 20, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 14, count_max = 20 }
     )
 
     table.insert(
       data.raw.turret["bob-small-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-medium-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-big-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 3, count_max = 6 }
     )
     table.insert(
       data.raw.turret["bob-huge-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 4, count_max = 8, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 4, count_max = 8 }
     )
     table.insert(
       data.raw.turret["bob-giant-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 10, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 10 }
     )
     table.insert(
       data.raw.turret["bob-titan-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 6, count_max = 12, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 6, count_max = 12 }
     )
     table.insert(
       data.raw.turret["bob-behemoth-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 9, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 9, count_max = 15 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-explosive-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 14, count_max = 20, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 14, count_max = 20 }
     )
 
     table.insert(
       data.raw.turret["bob-small-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-medium-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-big-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 3, count_max = 6 }
     )
     table.insert(
       data.raw.turret["bob-huge-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 4, count_max = 8, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 4, count_max = 8 }
     )
     table.insert(
       data.raw.turret["bob-giant-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 10, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 10 }
     )
     table.insert(
       data.raw.turret["bob-titan-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 6, count_max = 12, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 6, count_max = 12 }
     )
     table.insert(
       data.raw.turret["bob-behemoth-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 9, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 9, count_max = 15 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-poison-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 14, count_max = 20, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 14, count_max = 20 }
     )
 
     table.insert(
       data.raw.turret["bob-small-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 1, count_max = 3, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 1, count_max = 3 }
     )
     table.insert(
       data.raw.turret["bob-medium-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 2, count_max = 4, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 2, count_max = 4 }
     )
     table.insert(
       data.raw.turret["bob-big-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 3, count_max = 6, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 3, count_max = 6 }
     )
     table.insert(
       data.raw.turret["bob-huge-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 4, count_max = 8, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 4, count_max = 8 }
     )
     table.insert(
       data.raw.turret["bob-giant-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 5, count_max = 10, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 5, count_max = 10 }
     )
     table.insert(
       data.raw.turret["bob-titan-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 6, count_max = 12, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 6, count_max = 12 }
     )
     table.insert(
       data.raw.turret["bob-behemoth-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 9, count_max = 15, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 9, count_max = 15 }
     )
     table.insert(
       data.raw.turret["bob-leviathan-fire-worm-turret"].loot,
-      { item = "bob-alien-artifact", count_min = 14, count_max = 20, probability = 1 }
+      { item = "bob-alien-artifact", count_min = 14, count_max = 20 }
     )
   end
 end


### PR DESCRIPTION
Trim down artifact drops somewhat. Remove them from small biters/spitters entirely. This should still fit most players' needs easily enough, while reducing spillover onto belts.