### PR TITLE
Enemies functionality update

### DIFF
--- a/bobenemies/locale/en/bobenemies.cfg
+++ b/bobenemies/locale/en/bobenemies.cfg
@@ -324,6 +324,8 @@ bobmods-enemies-factionsappear=Evolution level for new factions
 bobmods-enemies-qualityenemies=Enemies may have boosted quality
 bobmods-enemies-originalcolors=Use original map color
 bobmods-enemies-radarscanlimit=Ground radar scan limit
+bobmods-enemies-randomizeenemies=Randomize enemy factions
+bobmods-enemies-factionlist=Faction list
 
 
 [mod-setting-description]
@@ -339,3 +341,5 @@ bobmods-enemies-factionsappear=Enemy evolution level at which new enemy factions
 bobmods-enemies-qualityenemies=New enemy base structures may spawn with increased quality, which will produce higher-quality units and higher-quality loot drops.
 bobmods-enemies-originalcolors=Enemy spawners will appear on the map with their original red color instead of faction-specific colors meant to make them easier to identify.
 bobmods-enemies-radarscanlimit=Limits the number of items on the ground that the ground radar will mark for deconstruction in a single cycle. While this may have a minor impact on performance, the main purpose is to keep construction robots from becoming occupied with picking up items for long periods of time. Setting to 0 will remove the limit.
+bobmods-enemies-randomizeenemies=New enemy factions will be unlocked in a random order. Can only be done at game start or when this mod is first added.
+bobmods-enemies-factionlist=List of all factions that appear. Separate each with a single comma and no spaces. Factions cannot be added mid-game, but they can be removed (though this is not recommended). Removing more than one may make it difficult to collect all artifact types. Factions belonging to this mod that are removed mid-game will not disappear from the map, but no new bases will be spawned.

--- a/bobenemies/settings.lua
+++ b/bobenemies/settings.lua
@@ -75,8 +75,20 @@ data:extend({
     type = "int-setting",
     name = "bobmods-enemies-radarscanlimit",
     setting_type = "startup",
-    default_value = 50,
+    default_value = 100,
     minimum_value = 0,
+  },
+  {
+    type = "bool-setting",
+    name = "bobmods-enemies-randomizeenemies",
+    setting_type = "startup",
+    default_value = false,
+  },
+  {
+    type = "string-setting",
+    name = "bobmods-enemies-factionlist",
+    setting_type = "startup",
+    default_value = "piercing,electric,acid,explosive,poison,fire",
   },
 })
 


### PR DESCRIPTION
Revises control.lua to allow for new factions to be added by other mods. I am currently still running tests, but everything seems to be working as intended. There are some log() and game.print() that need to be removed when testing is done.

Unlock and faction lists are now populated on_init. Factions can only be added at this stage.
With a new setting enabled, faction unlock order may also be randomized at this stage.
Factions may be removed on_configuration_changed, in the event that another mod that adds factions is removed.
Various functions have been updated to work with any number of factions.
Functions will still be unlocked in three groups of equal-ish size. If the split is not even by 1, the last faction will go to the third group, and if by 2, the second and third will both have +1.
Removed the section of determine_faction_flag where nearby spawners are used to determine faction. It was slow and rarely needed because if there are no flags nearby, there will almost always be no spawners either. In this situation, the result will now always be random.
Spawners and Worms will now raise_built when they are created, which will allow other mods to interact with them.

Enemy quality tables nerfed a bit to be a little less difficult.
Worms of later tiers will now only appear at slightly higher evo levels.