### PR TITLE
Shotgun ammo update

### DIFF
--- a/bobwarfare/prototypes/entity/effects.lua
+++ b/bobwarfare/prototypes/entity/effects.lua
@@ -414,4 +414,27 @@ data:extend({
     target_movement_modifier = 0.8,
     damage_per_tick = { amount = 8, type = "bob-plasma" },
   },
+  {
+    type = "sticker",
+    name = "bob-plasma-sticker-small",
+    flags = { "not-on-map" },
+
+    animation = {
+      filename = "__base__/graphics/entity/fire-flame/fire-flame-02.png",
+      draw_as_glow = true,
+      line_length = 10,
+      frame_count = 90,
+      width = 82,
+      height = 106,
+      blend_mode = "additive",
+      animation_speed = 1,
+      scale = 0.4,
+      tint = { r = 0.0, g = 0.2, b = 1, a = 0.5 },
+    },
+
+    duration_in_ticks = 2 * 60,
+    damage_interval = 10,
+    target_movement_modifier = 0.8,
+    damage_per_tick = { amount = 5, type = "bob-plasma" },
+  },
 })

--- a/bobwarfare/prototypes/entity/projectiles.lua
+++ b/bobwarfare/prototypes/entity/projectiles.lua
@@ -6,16 +6,30 @@ data:extend({
     type = "projectile",
     name = "bob-better-shotgun-projectile",
     flags = { "not-on-map" },
-    collision_box = { { -0.05, -1 }, { 0.05, 1 } },
+    collision_box = { { -0.1, -0.25 }, { 0.1, 0.25 } },
     acceleration = 0,
-    direction_only = true,
+    hit_at_collision_position = true,
     action = {
       type = "direct",
       action_delivery = {
         type = "instant",
         target_effects = {
-          type = "damage",
-          damage = { amount = 12, type = "physical" },
+          {
+            type = "activate-impact",
+            deliver_category = "bullet",
+          },
+          {
+            type = "damage",
+            damage = { amount = 14, type = "physical" },
+          },
+          {
+            type = "create-entity",
+            entity_name = "small-explosion-hit",
+          },
+          {
+            type = "create-sticker",
+            sticker = "shotgun-impact-sticker",
+          },
         },
       },
     },
@@ -34,16 +48,30 @@ data:extend({
     type = "projectile",
     name = "bob-shotgun-ap-projectile",
     flags = { "not-on-map" },
-    collision_box = { { -0.05, -1 }, { 0.05, 1 } },
+    collision_box = { { -0.1, -0.25 }, { 0.1, 0.25 } },
     acceleration = 0,
-    direction_only = true,
+    hit_at_collision_position = true,
     action = {
       type = "direct",
       action_delivery = {
         type = "instant",
         target_effects = {
-          type = "damage",
-          damage = { amount = 14, type = "bob-pierce" },
+          {
+            type = "activate-impact",
+            deliver_category = "bullet",
+          },
+          {
+            type = "damage",
+            damage = { amount = 14, type = "bob-pierce" },
+          },
+          {
+            type = "create-entity",
+            entity_name = "small-explosion-hit",
+          },
+          {
+            type = "create-sticker",
+            sticker = "shotgun-impact-sticker",
+          },
         },
       },
     },
@@ -62,16 +90,30 @@ data:extend({
     type = "projectile",
     name = "bob-shotgun-electric-projectile",
     flags = { "not-on-map" },
-    collision_box = { { -0.05, -1 }, { 0.05, 1 } },
+    collision_box = { { -0.1, -0.25 }, { 0.1, 0.25 } },
     acceleration = 0,
-    direction_only = true,
+    hit_at_collision_position = true,
     action = {
       type = "direct",
       action_delivery = {
         type = "instant",
         target_effects = {
-          type = "damage",
-          damage = { amount = 14, type = "electric" },
+          {
+            type = "activate-impact",
+            deliver_category = "bullet",
+          },
+          {
+            type = "damage",
+            damage = { amount = 14, type = "electric" },
+          },
+          {
+            type = "create-entity",
+            entity_name = "small-explosion-hit",
+          },
+          {
+            type = "create-sticker",
+            sticker = "shotgun-impact-sticker",
+          },
         },
       },
     },
@@ -90,18 +132,14 @@ data:extend({
     type = "projectile",
     name = "bob-shotgun-explosive-projectile",
     flags = { "not-on-map" },
-    collision_box = { { -0.5, -1 }, { 0.5, 1 } },
+    collision_box = { { -0.25, -0.25 }, { 0.25, 0.25 } },
     acceleration = 0,
-    direction_only = true,
+    hit_at_collision_position = true,
     action = {
       type = "direct",
       action_delivery = {
         type = "instant",
         target_effects = {
-          {
-            type = "create-entity",
-            entity_name = "explosion",
-          },
           {
             type = "nested-result",
             action = {
@@ -111,12 +149,20 @@ data:extend({
                 type = "instant",
                 target_effects = {
                   {
+                    type = "activate-impact",
+                    deliver_category = "bullet",
+                  },
+                  {
                     type = "damage",
                     damage = { amount = 10, type = "explosion" },
                   },
                 },
               },
             },
+          },
+          {
+            type = "create-entity",
+            entity_name = "explosion",
           },
         },
       },
@@ -146,9 +192,9 @@ data:extend({
     type = "projectile",
     name = "bob-shotgun-flame-projectile",
     flags = { "not-on-map" },
-    collision_box = { { -0.5, -1 }, { 0.5, 1 } },
+    collision_box = { { -0.25, -0.25 }, { 0.25, 0.25 } },
     acceleration = 0,
-    direction_only = true,
+    hit_at_collision_position = true,
     action = {
       type = "direct",
       action_delivery = {
@@ -163,12 +209,20 @@ data:extend({
                 type = "instant",
                 target_effects = {
                   {
+                    type = "activate-impact",
+                    deliver_category = "bullet",
+                  },
+                  {
                     type = "damage",
                     damage = { amount = 10, type = "fire" },
                   },
                 },
               },
             },
+          },
+          {
+            type = "create-entity",
+            entity_name = "explosion",
           },
         },
       },
@@ -198,9 +252,9 @@ data:extend({
     type = "projectile",
     name = "bob-shotgun-acid-projectile",
     flags = { "not-on-map" },
-    collision_box = { { -0.5, -1 }, { 0.5, 1 } },
+    collision_box = { { -0.25, -0.25 }, { 0.25, 0.25 } },
     acceleration = 0,
-    direction_only = true,
+    hit_at_collision_position = true,
     action = {
       type = "direct",
       action_delivery = {
@@ -215,12 +269,20 @@ data:extend({
                 type = "instant",
                 target_effects = {
                   {
+                    type = "activate-impact",
+                    deliver_category = "bullet",
+                  },
+                  {
                     type = "damage",
                     damage = { amount = 10, type = "acid" },
                   },
                 },
               },
             },
+          },
+          {
+            type = "create-entity",
+            entity_name = "explosion",
           },
         },
       },
@@ -250,9 +312,9 @@ data:extend({
     type = "projectile",
     name = "bob-shotgun-poison-projectile",
     flags = { "not-on-map" },
-    collision_box = { { -0.5, -1 }, { 0.5, 1 } },
+    collision_box = { { -0.25, -0.25 }, { 0.25, 0.25 } },
     acceleration = 0,
-    direction_only = true,
+    hit_at_collision_position = true,
     action = {
       type = "direct",
       action_delivery = {
@@ -267,12 +329,20 @@ data:extend({
                 type = "instant",
                 target_effects = {
                   {
+                    type = "activate-impact",
+                    deliver_category = "bullet",
+                  },
+                  {
                     type = "damage",
                     damage = { amount = 10, type = "poison" },
                   },
                 },
               },
             },
+          },
+          {
+            type = "create-entity",
+            entity_name = "explosion",
           },
         },
       },
@@ -302,16 +372,30 @@ data:extend({
     type = "projectile",
     name = "bob-shotgun-uranium-projectile",
     flags = { "not-on-map" },
-    collision_box = { { -0.05, -1 }, { 0.05, 1 } },
+    collision_box = { { -0.1, -0.25 }, { 0.1, 0.25 } },
     acceleration = 0,
-    direction_only = true,
+    hit_at_collision_position = true,
     action = {
       type = "direct",
       action_delivery = {
         type = "instant",
         target_effects = {
-          type = "damage",
-          damage = { amount = 25, type = "physical" },
+          {
+            type = "activate-impact",
+            deliver_category = "bullet",
+          },
+          {
+            type = "damage",
+            damage = { amount = 25, type = "physical" },
+          },
+          {
+            type = "create-entity",
+            entity_name = "small-explosion-hit",
+          },
+          {
+            type = "create-sticker",
+            sticker = "shotgun-impact-sticker",
+          },
         },
       },
     },
@@ -824,15 +908,19 @@ data:extend({
     name = "cannon-projectile-pellet",
     flags = { "not-on-map" },
     force_condition = "not-same",
-    collision_box = { { -0.05, -0.25 }, { 0.05, 0.25 } },
+    collision_box = { { -0.1, -0.25 }, { 0.1, 0.25 } },
     acceleration = 0,
-    direction_only = true,
+    hit_at_collision_position = true,
     piercing_damage = 30,
     action = {
       type = "direct",
       action_delivery = {
         type = "instant",
         target_effects = {
+          {
+            type = "activate-impact",
+            deliver_category = "bullet",
+          },
           {
             type = "damage",
             damage = { amount = 20, type = "physical" },
@@ -844,6 +932,14 @@ data:extend({
           {
             type = "damage",
             damage = { amount = 10, type = "explosion" },
+          },
+          {
+            type = "create-entity",
+            entity_name = "small-explosion-hit",
+          },
+          {
+            type = "create-sticker",
+            sticker = "shotgun-impact-sticker",
           },
         },
       },
@@ -1605,9 +1701,9 @@ data:extend({
     type = "projectile",
     name = "bob-shotgun-plasma-projectile",
     flags = { "not-on-map" },
-    collision_box = { { -0.5, -1 }, { 0.5, 1 } },
+    collision_box = { { -0.25, -0.25 }, { 0.25, 0.25 } },
     acceleration = 0,
-    direction_only = true,
+    hit_at_collision_position = true,
     action = {
       type = "direct",
       action_delivery = {
@@ -1616,22 +1712,42 @@ data:extend({
           {
             type = "nested-result",
             action = {
-              type = "area",
-              radius = 1,
-              action_delivery = {
-                type = "instant",
-                target_effects = {
-                  {
-                    type = "damage",
-                    damage = { amount = 15, type = "bob-plasma" },
+              {
+                type = "area",
+                radius = 1,
+                action_delivery = {
+                  type = "instant",
+                  target_effects = {
+                    {
+                      type = "activate-impact",
+                      deliver_category = "bullet",
+                    },
+                    {
+                      type = "damage",
+                      damage = { amount = 15, type = "bob-plasma" },
+                    },
                   },
-                  {
-                    type = "create-sticker",
-                    sticker = "bob-plasma-sticker",
+                },
+              },
+              {
+                type = "area",
+                radius = 1,
+                force = "not-same",
+                action_delivery = {
+                  type = "instant",
+                  target_effects = {
+                    {
+                      type = "create-sticker",
+                      sticker = "bob-plasma-sticker-small",
+                    },
                   },
                 },
               },
             },
+          },
+          {
+            type = "create-entity",
+            entity_name = "explosion",
           },
         },
       },
@@ -1683,7 +1799,7 @@ data:extend({
                   },
                   {
                     type = "create-sticker",
-                    sticker = "bob-plasma-sticker",
+                    sticker = "bob-plasma-sticker-small",
                     show_in_tooltip = true,
                   },
                 },
@@ -1735,25 +1851,19 @@ if
   and data.raw.fluid["bob-alien-fire"]
   and data.raw.fluid["bob-alien-poison"]
 then
-  data.raw.projectile["bob-better-shotgun-projectile"].action.action_delivery.target_effects.damage.amount = 16
-  data.raw.projectile["bob-shotgun-uranium-projectile"].action.action_delivery.target_effects.damage.amount = 24
-  data.raw.projectile["bob-shotgun-ap-projectile"].action.action_delivery.target_effects.damage.amount = 27
-  data.raw.projectile["bob-shotgun-electric-projectile"].action.action_delivery.target_effects.damage.amount = 27
-  data.raw.ammo["bob-shotgun-acid-shell"].ammo_type.action.repeat_count = 15
-  data.raw.projectile["bob-shotgun-acid-projectile"].action.action_delivery.target_effects[1].action.action_delivery.target_effects[1].damage.amount =
+  data.raw.projectile["bob-better-shotgun-projectile"].action.action_delivery.target_effects[2].damage.amount = 16
+  data.raw.projectile["bob-shotgun-uranium-projectile"].action.action_delivery.target_effects[2].damage.amount = 24
+  data.raw.projectile["bob-shotgun-ap-projectile"].action.action_delivery.target_effects[2].damage.amount = 27
+  data.raw.projectile["bob-shotgun-electric-projectile"].action.action_delivery.target_effects[2].damage.amount = 27
+  data.raw.projectile["bob-shotgun-acid-projectile"].action.action_delivery.target_effects[1].action.action_delivery.target_effects[2].damage.amount =
     22
-  data.raw.ammo["bob-shotgun-explosive-shell"].ammo_type.action.repeat_count = 15
-  data.raw.projectile["bob-shotgun-explosive-projectile"].action.action_delivery.target_effects[2].action.action_delivery.target_effects[1].damage.amount =
+  data.raw.projectile["bob-shotgun-explosive-projectile"].action.action_delivery.target_effects[1].action.action_delivery.target_effects[2].damage.amount =
     22
-  data.raw.ammo["bob-shotgun-flame-shell"].ammo_type.action.repeat_count = 15
-  data.raw.projectile["bob-shotgun-flame-projectile"].action.action_delivery.target_effects[1].action.action_delivery.target_effects[1].damage.amount =
+  data.raw.projectile["bob-shotgun-flame-projectile"].action.action_delivery.target_effects[1].action.action_delivery.target_effects[2].damage.amount =
     22
-  data.raw.ammo["bob-shotgun-poison-shell"].ammo_type.action.repeat_count = 15
-  data.raw.projectile["bob-shotgun-poison-projectile"].action.action_delivery.target_effects[1].action.action_delivery.target_effects[1].damage.amount =
+  data.raw.projectile["bob-shotgun-poison-projectile"].action.action_delivery.target_effects[1].action.action_delivery.target_effects[2].damage.amount =
     22
-  data.raw.ammo["bob-shotgun-plasma-shell"].ammo_type.action.repeat_count = 15
-  data.raw.ammo["bob-shotgun-plasma-shell"].ammo_type.action.repeat_count = 20
-  data.raw.projectile["bob-shotgun-plasma-projectile"].action.action_delivery.target_effects[1].action.action_delivery.target_effects[1].damage.amount =
+  data.raw.projectile["bob-shotgun-plasma-projectile"].action.action_delivery.target_effects[1].action[1].action_delivery.target_effects[2].damage.amount =
     30
 
   data.raw.projectile["bob-piercing-rocket"].action.action_delivery.target_effects[2].damage.amount = 160

--- a/bobwarfare/prototypes/item/ammo.lua
+++ b/bobwarfare/prototypes/item/ammo.lua
@@ -30,6 +30,59 @@ local function bobmissileammo(projectile)
   }
 end
 
+local function bobshotgunammo(projectile, count, radius)
+  return {
+    force_clamp_to_max_range = true,
+    target_type = "direction",
+    action = {
+      {
+        type = "direct",
+        action_delivery = {
+          type = "instant",
+          source_effects = {
+            {
+              entity_name = "explosion-gunshot",
+              type = "create-explosion"
+            }
+          },
+          target_effects = {
+            type = "nested-result",
+            action = {
+              type = "area",
+              radius = radius or 2.5,
+              repeat_count = count or 12,
+              target_entities = false,
+              action_delivery = {
+                inherit_speed = true,
+                projectile = projectile,
+                starting_speed = 1,
+                starting_speed_deviation = 0.1,
+                type = "projectile"
+              },
+            },
+          },
+        },
+      },
+    },
+  }
+end
+
+local aliencount1 = 20
+local aliencount2 = 15
+local alienspread = 2.75
+if
+  data.raw.item["bob-alien-orange-alloy"]
+  and data.raw.item["bob-alien-blue-alloy"]
+  and data.raw.fluid["bob-alien-explosive"]
+  and data.raw.fluid["bob-alien-acid"]
+  and data.raw.fluid["bob-alien-fire"]
+  and data.raw.fluid["bob-alien-poison"]
+then
+  aliencount1 = 24
+  aliencount2 = 18
+  alienspread = 3.25
+end
+
 local ammodropmove = {
   filename = "__base__/sound/item/ammo-small-inventory-move.ogg",
   volume = 0.8,
@@ -432,25 +485,7 @@ data:extend({
     stack_size = 100,
     magazine_size = 10,
     ammo_category = "shotgun-shell",
-    ammo_type = {
-      target_type = "direction",
-      action = {
-        type = "direct",
-        repeat_count = 20,
-        action_delivery = {
-          type = "projectile",
-          projectile = "bob-better-shotgun-projectile",
-          starting_speed = 1,
-          direction_deviation = 0.4,
-          range_deviation = 0.4,
-          max_range = 15,
-          source_effects = {
-            type = "create-entity",
-            entity_name = "explosion-gunshot",
-          },
-        },
-      },
-    },
+    ammo_type = bobshotgunammo("bob-better-shotgun-projectile", 20, 2.75),
     drop_sound = ammodropmove,
     inventory_move_sound = ammodropmove,
     pick_sound = ammopickup,
@@ -467,25 +502,7 @@ data:extend({
     stack_size = 100,
     magazine_size = 10,
     ammo_category = "shotgun-shell",
-    ammo_type = {
-      target_type = "direction",
-      action = {
-        type = "direct",
-        repeat_count = 20,
-        action_delivery = {
-          type = "projectile",
-          projectile = "bob-shotgun-ap-projectile",
-          starting_speed = 1,
-          direction_deviation = 0.4,
-          range_deviation = 0.4,
-          max_range = 15,
-          source_effects = {
-            type = "create-entity",
-            entity_name = "explosion-gunshot",
-          },
-        },
-      },
-    },
+    ammo_type = bobshotgunammo("bob-shotgun-ap-projectile", aliencount1, alienspread),
     drop_sound = ammodropmove,
     inventory_move_sound = ammodropmove,
     pick_sound = ammopickup,
@@ -502,25 +519,7 @@ data:extend({
     stack_size = 100,
     magazine_size = 10,
     ammo_category = "shotgun-shell",
-    ammo_type = {
-      target_type = "direction",
-      action = {
-        type = "direct",
-        repeat_count = 20,
-        action_delivery = {
-          type = "projectile",
-          projectile = "bob-shotgun-electric-projectile",
-          starting_speed = 1,
-          direction_deviation = 0.4,
-          range_deviation = 0.4,
-          max_range = 15,
-          source_effects = {
-            type = "create-entity",
-            entity_name = "explosion-gunshot",
-          },
-        },
-      },
-    },
+    ammo_type = bobshotgunammo("bob-shotgun-electric-projectile", aliencount1, alienspread),
     drop_sound = ammodropmove,
     inventory_move_sound = ammodropmove,
     pick_sound = ammopickup,
@@ -537,25 +536,7 @@ data:extend({
     stack_size = 100,
     magazine_size = 10,
     ammo_category = "shotgun-shell",
-    ammo_type = {
-      target_type = "direction",
-      action = {
-        type = "direct",
-        repeat_count = 10,
-        action_delivery = {
-          type = "projectile",
-          projectile = "bob-shotgun-explosive-projectile",
-          starting_speed = 0.5,
-          direction_deviation = 0.4,
-          range_deviation = 0.4,
-          max_range = 15,
-          source_effects = {
-            type = "create-entity",
-            entity_name = "explosion-gunshot",
-          },
-        },
-      },
-    },
+    ammo_type = bobshotgunammo("bob-shotgun-explosive-projectile", aliencount2, alienspread),
     drop_sound = ammodropmove,
     inventory_move_sound = ammodropmove,
     pick_sound = ammopickup,
@@ -572,25 +553,7 @@ data:extend({
     stack_size = 100,
     magazine_size = 10,
     ammo_category = "shotgun-shell",
-    ammo_type = {
-      target_type = "direction",
-      action = {
-        type = "direct",
-        repeat_count = 10,
-        action_delivery = {
-          type = "projectile",
-          projectile = "bob-shotgun-flame-projectile",
-          starting_speed = 0.5,
-          direction_deviation = 0.4,
-          range_deviation = 0.4,
-          max_range = 15,
-          source_effects = {
-            type = "create-entity",
-            entity_name = "explosion-gunshot",
-          },
-        },
-      },
-    },
+    ammo_type = bobshotgunammo("bob-shotgun-flame-projectile", aliencount2, alienspread),
     drop_sound = ammodropmove,
     inventory_move_sound = ammodropmove,
     pick_sound = ammopickup,
@@ -607,25 +570,7 @@ data:extend({
     stack_size = 100,
     magazine_size = 10,
     ammo_category = "shotgun-shell",
-    ammo_type = {
-      target_type = "direction",
-      action = {
-        type = "direct",
-        repeat_count = 10,
-        action_delivery = {
-          type = "projectile",
-          projectile = "bob-shotgun-acid-projectile",
-          starting_speed = 0.5,
-          direction_deviation = 0.4,
-          range_deviation = 0.4,
-          max_range = 15,
-          source_effects = {
-            type = "create-entity",
-            entity_name = "explosion-gunshot",
-          },
-        },
-      },
-    },
+    ammo_type = bobshotgunammo("bob-shotgun-acid-projectile", aliencount2, alienspread),
     drop_sound = ammodropmove,
     inventory_move_sound = ammodropmove,
     pick_sound = ammopickup,
@@ -642,25 +587,7 @@ data:extend({
     stack_size = 100,
     magazine_size = 10,
     ammo_category = "shotgun-shell",
-    ammo_type = {
-      target_type = "direction",
-      action = {
-        type = "direct",
-        repeat_count = 10,
-        action_delivery = {
-          type = "projectile",
-          projectile = "bob-shotgun-poison-projectile",
-          starting_speed = 0.5,
-          direction_deviation = 0.4,
-          range_deviation = 0.4,
-          max_range = 15,
-          source_effects = {
-            type = "create-entity",
-            entity_name = "explosion-gunshot",
-          },
-        },
-      },
-    },
+    ammo_type = bobshotgunammo("bob-shotgun-poison-projectile", aliencount2, alienspread),
     drop_sound = ammodropmove,
     inventory_move_sound = ammodropmove,
     pick_sound = ammopickup,
@@ -677,25 +604,7 @@ data:extend({
     stack_size = 100,
     magazine_size = 10,
     ammo_category = "shotgun-shell",
-    ammo_type = {
-      target_type = "direction",
-      action = {
-        type = "direct",
-        repeat_count = 20,
-        action_delivery = {
-          type = "projectile",
-          projectile = "bob-shotgun-uranium-projectile",
-          starting_speed = 1,
-          direction_deviation = 0.4,
-          range_deviation = 0.4,
-          max_range = 15,
-          source_effects = {
-            type = "create-entity",
-            entity_name = "explosion-gunshot",
-          },
-        },
-      },
-    },
+    ammo_type = bobshotgunammo("bob-shotgun-uranium-projectile", 24, 3.25),
     drop_sound = ammodropmove,
     inventory_move_sound = ammodropmove,
     pick_sound = ammopickup,
@@ -1014,25 +923,7 @@ data:extend({
       },
     },
     ammo_category = "cannon-shell",
-    ammo_type = {
-      target_type = "direction",
-      action = {
-        type = "direct",
-        repeat_count = 20,
-        action_delivery = {
-          type = "projectile",
-          projectile = "cannon-projectile-pellet",
-          starting_speed = 1,
-          direction_deviation = 0.5,
-          range_deviation = 0.3,
-          max_range = 20,
-          source_effects = {
-            type = "create-entity",
-            entity_name = "explosion-gunshot",
-          },
-        },
-      },
-    },
+    ammo_type = bobshotgunammo("cannon-projectile-pellet", 24, 3),
     subgroup = "ammo",
     order = "d[cannon-shell]-c[scatter]",
     stack_size = 100,
@@ -1424,25 +1315,7 @@ data:extend({
     stack_size = 100,
     magazine_size = 10,
     ammo_category = "shotgun-shell",
-    ammo_type = {
-      target_type = "direction",
-      action = {
-        type = "direct",
-        repeat_count = 10,
-        action_delivery = {
-          type = "projectile",
-          projectile = "bob-shotgun-plasma-projectile",
-          starting_speed = 0.5,
-          direction_deviation = 0.4,
-          range_deviation = 0.4,
-          max_range = 15,
-          source_effects = {
-            type = "create-entity",
-            entity_name = "explosion-gunshot",
-          },
-        },
-      },
-    },
+    ammo_type = bobshotgunammo("bob-shotgun-plasma-projectile", 28, 3.5),
     drop_sound = ammodropmove,
     inventory_move_sound = ammodropmove,
     pick_sound = ammopickup,


### PR DESCRIPTION
Updates Bob's shotgun ammo to conform to the changes made to vanilla shotgun ammo in 2.1. The new way they work definitely feels less unwieldy, and since the projectiles now aim for a circular area instead of flying off in a wide arc, they're very effective at hitting big targets like nests.

Also added a new shorter-duration plasma sticker, because the normal one was way too powerful for a handheld weapon like this, and had a tendency to kill the user. Now that sticker only affects targets from a not-same force.