### PR TITLE
AAI integration fixes

### DIFF
--- a/bobplates/prototypes/aai-integration.lua
+++ b/bobplates/prototypes/aai-integration.lua
@@ -38,7 +38,7 @@ if mods["aai-industry"] then
   bobmods.lib.tech.add_prerequisite("bob-chemical-processing-1", "basic-fluid-handling")
 
   if mods["bobtech"] then
-    data.raw.technology["sand-processing"].research_trigger = { type = "mine-entity", entity = "bob-quartz" }
+    data.raw.technology["sand-processing"].research_trigger = { type = "mine-entity", entities = { "bob-quartz" } }
     data.raw.technology["sand-processing"].unit = nil
     data.raw.technology["glass-processing"].research_trigger = { type = "craft-item", item = "sand", count = 10 }
     data.raw.technology["glass-processing"].unit = nil

--- a/bobtech/prototypes/technology/technology-updates.lua
+++ b/bobtech/prototypes/technology/technology-updates.lua
@@ -1,5 +1,7 @@
 if mods["bobelectronics"] then
-  bobmods.lib.recipe.replace_ingredient("automation-science-pack", "copper-plate", "bob-basic-circuit-board")
+  if not mods["aai-industry"] then
+    bobmods.lib.recipe.replace_ingredient("automation-science-pack", "copper-plate", "bob-basic-circuit-board")
+  end
   bobmods.lib.recipe.add_ingredient("logistic-science-pack", { type = "item", name = "electronic-circuit", amount = 1 })
 end
 


### PR DESCRIPTION
Fixes fail to load due to update to research trigger ("mine-entity" now requires an "entities" table parameter instead of singular "entity")

Adds a check so that SP1 does not require a Basic Circuit Board if AAI is active in order to resolve a tech order conflict.