### PR TITLE
Add neighbour_connectable to burner reactors

### DIFF
--- a/bobpower/prototypes/burner-reactor.lua
+++ b/bobpower/prototypes/burner-reactor.lua
@@ -95,6 +95,42 @@ if settings.startup["bobmods-power-heatsources"].value == true then
       },
       consumption = "0.6MW",
       neighbour_bonus = 0.25,
+      neighbour_connectable = {
+        connections = {
+          {
+            category = "burner-reactor",
+            location = {
+              direction = defines.direction.north,
+              position = { 0, -1.5 }
+            },
+            neighbour_category = { "burner-reactor" }
+          },
+          {
+            category = "burner-reactor",
+            location = {
+              direction = defines.direction.east,
+              position = { 1.5, 0 }
+            },
+            neighbour_category = { "burner-reactor" }
+          },
+          {
+            category = "burner-reactor",
+            location = {
+              direction = defines.direction.south,
+              position = { 0, 1.5 }
+            },
+            neighbour_category = { "burner-reactor" }
+          },
+          {
+            category = "burner-reactor",
+            location = {
+              direction = defines.direction.west,
+              position = { -1.5, 0 }
+            },
+            neighbour_category = { "burner-reactor" }
+          },
+        },
+      },
       scale_energy_usage = false,
       energy_source = {
         type = "burner",


### PR DESCRIPTION
Addresses #618. Thanks to wanne32 for doing most of the work.

Adds neighbour_connectable parameter to Burner Reactor 1, which is then copied over to all subsequent Burner/Fluid Reactors. Tested to ensure that reactors must be placed in-line with each other, not offset by a tile, in order to get neighbor bonuses.