### PR TITLE
Classes space update

### DIFF
--- a/bobclasses/control.lua
+++ b/bobclasses/control.lua
@@ -945,6 +945,8 @@ function close_avatar_gui(player_index)
 
     globtable.gui = nil
     globtable.buttons_row = nil
+    globtable.help_row = nil
+    globtable.help_row2 = nil
     globtable.characters_list = nil
     globtable.minimap_gui = nil
     globtable.current_character = nil
@@ -985,7 +987,7 @@ function draw_avatar_gui(player_index)
     horizontal_scroll_policy = "never",
   })
   gui.main_flow.characters_frame.bob_avatar_list.style.minimal_height = 0
-  gui.main_flow.characters_frame.bob_avatar_list.style.maximal_height = 250
+  gui.main_flow.characters_frame.bob_avatar_list.style.maximal_height = 400
   gui.main_flow.characters_frame.bob_avatar_list.style.right_padding = 4
   draw_characters_list(player_index)
 
@@ -994,7 +996,13 @@ function draw_avatar_gui(player_index)
   globtable.buttons_row = gui.add({ type = "flow", name = "cheat_buttons_flow" })
   gui.cheat_buttons_flow.style.top_padding = 8
   gui.cheat_buttons_flow.style.horizontally_stretchable = true
+
+  globtable.help_row = gui.add({ type = "flow", name = "help_message_box" })
+  gui.help_message_box.style.top_padding = 8
+  globtable.help_row2 = gui.add({ type = "flow", name = "help_message_box2" })
+
   draw_buttons_row(player_index)
+  draw_hub_message(player_index)
 end
 
 function draw_current_character_info(player_index)
@@ -1128,8 +1136,12 @@ function draw_characters_list(player_index)
         draw_vertical_lines = false,
       })
     end
-    for i, entity in pairs(characters) do
-      gui.table.add({ type = "label", name = "bob_avatar_list_number_" .. i, caption = string.format("#%d ", i) })
+
+    local char_number = 1
+    for i = #characters, 1, -1 do
+      local entity = characters[i]
+      gui.table.add({ type = "label", name = "bob_avatar_list_number_" .. i, caption = string.format("#%d ", char_number) })
+      char_number = char_number + 1
       if not storage.sprite[entity.unit_number] then
         reset_character_icon(entity)
       end
@@ -1177,7 +1189,37 @@ function draw_characters_list(player_index)
         gui.table["bob_avatar_list_minimap_" .. i].style = "selected_mod_gui_button_28"
       end
     end
+
   end
+end
+
+function draw_hub_message(player_index)
+
+  local player = game.players[player_index]
+  local gui = storage.players[player_index].help_row
+  local gui2 = storage.players[player_index].help_row2
+  if gui and gui2 then
+    gui.clear()
+    gui2.clear()
+
+    if
+      player.character.surface.platform
+      and player.character.surface.platform.hub
+      and (not player.hub)
+    then
+      gui.add({
+        type = "label",
+        name = "help-message-label",
+        caption = { "gui.bob-avatar-hub-help" },
+      })
+      gui2.add({
+        type = "label",
+        name = "help-message-label",
+        caption = { "gui.bob-avatar-hub-help2" },
+      })
+    end
+  end
+
 end
 
 function refresh_buttons_row(player_index)
@@ -1189,6 +1231,7 @@ function refresh_avatar_gui(player_index)
   wlog("Entered function refresh_avatar_gui(" .. player_index .. ")!")
   draw_current_character_info(player_index)
   draw_characters_list(player_index)
+  draw_hub_message(player_index)
 end
 
 function refresh_minimap_buttons(player_index)

--- a/bobclasses/locale/en/bobclasses.cfg
+++ b/bobclasses/locale/en/bobclasses.cfg
@@ -103,7 +103,7 @@ bob-class-pick=Select a character class
 
 bob-class-balanced=[font=default-semibold][color=255,230,192]The Balanced class[/color][/font] is basic but well rounded.\n\nCrafting speed: 2\nReach: 10\nMax health: 300\nHealing: 11/second\nTime to start healing: 8 seconds\nInventory size: 80\nGun slots: 3\nRunning speed: 0.15\nMining speed: 0.5
 bob-class-miner=[font=default-semibold][color=255,230,192]The Crafter class[/color][/font] is well equipped for efficient and versatile portable manufacturing.\n\nCrafting speed: 3\nReach: 10\nMax health: 200\nHealing: 6/second\nTime to start healing: 12 seconds\nInventory size: 100\nGun slots: 2\nRunning speed: 0.12\nMining speed: 1\nSpecial: Can use smelting and machine crafting recipes.
-bob-class-fighter=[font=default-semibold][color=255,230,192]The Fighter class[/color][/font] is fast, heals quickly, and has various improvements to its combat strength. Starts with better weapons and equipment.\n\nCrafting speed: 1\nReach: 8\nMax health: 400\nHealing: 18/second\nTime to start healing: 3 seconds\nInventory size: 60\nGun slots: 5\nRunning speed: 0.2\nMining speed: 0.5\nExtra robot followers: 10\nSpecial: Immune to poison clouds, stronger melee attack.
+bob-class-fighter=[font=default-semibold][color=255,230,192]The Fighter class[/color][/font] is fast, heals quickly, and has various improvements to its combat strength. At the beginning of the game, spawns with better weapons and equipment.\n\nCrafting speed: 1\nReach: 8\nMax health: 400\nHealing: 18/second\nTime to start healing: 3 seconds\nInventory size: 60\nGun slots: 5\nRunning speed: 0.2\nMining speed: 0.5\nExtra robot followers: 10\nSpecial: Immune to poison clouds, stronger melee attack.
 bob-class-builder=[font=default-semibold][color=255,230,192]The Builder class[/color][/font] is geared toward making the process of building a factory and smooth and easy as possible.\n\nCrafting speed: 1\nReach: 15\nMax health: 200\nHealing: 6/second\nTime to start healing: 12 seconds\nInventory size: 100\nGun slots: 2\nRunning speed: 0.15\nMining speed: 1\nSpecial: Belt immunity.
 
 bob-class-balanced-2=[font=default-semibold][color=255,230,192]The Balanced 2 class[/color][/font] is well rounded, with slight improvements to health, inventory size, reach, and run speed.\n\nCrafting speed: 3\nReach: 13\nMax health: 450\nHealing: 18/second\nTime to start healing: 5 seconds\nInventory size: 100\nGun slots: 3\nRunning speed: 0.2\nMining speed: 1
@@ -120,6 +120,8 @@ bob-avatar-show-menu=Toggle character selection frame
 bob-avatar-switch=Change to this character
 bob-avatar-minimap=Opens a minimap of this character's location.
 bob-avatar-seticon=Click here while holding an item to set it as a character's icon
+bob-avatar-hub-help=Press the Enter/Leave Vehicle key,
+bob-avatar-hub-help2=__CONTROL__toggle-driving__, to take control of the platform hub.
 
 bob-avatar-god-mode=God mode
 bob-avatar-god-mode-tooltip=God mode is where you have free camera movement without controlling a character.\nWarning: if your body is killed while you are in god mode, it won't respawn.


### PR DESCRIPTION
Addresses #620 and #609.

To deal with the issue of Space Age tending to need quite a few different bodies, the maximum height of the Avatar Switcher character list is increased from 250 to 400. Additionally, I reversed the order that characters are listed in. Previously, new bodies and bodies you just switched out of would go on the bottom of the list. Now they go on the top, which should generally be where you'd want them for quick access.

Also, to help with people getting stuck on space platforms and unable to send their characters down to a planet, I have added a message that will show up on the Avatar Switcher box with instructions for how to solve the issue - you need to hit the enter vehicle button to enter the Hub. Then you can rocket down to whatever planet you're in orbit of. This message only shows up when it's needed - when you're controlling a character that is on a space platform but not in a Hub. Hopefully I covered all the bases. Gui stuff still doesn't really make sense to me.

Finally, since I saw it requested somewhere, I adjusted the wording on the Fighter class's description to make it clear that it only gets its special equipment at game start.

Edit:
Addresses #619.

Adds a backup for player-given character names. Now, each player will have their most recent (that is, current) character's name indexes by player name. This is to deal with the issue of character names disappearing due to the Jetpack mod - a consequence of the fact that the character is replaced each time a Jetpack is turned on or off. Now, whenever the gui is updated, it checks whether the controlled character has started or stopped flying. But what if the Jetpack-using character is not the one being controlled? Well, since there's a long-standing issue where the game will crash if a character using a Jetpack lands (runs out of fuel) while not being controlled by a player, I decided to block character switching when you're using a Jetpack. Thus, the only character that can be flying is the one you're controlling.

I also removed the old_character.active = false and new_character.active = true bits from the Jetpack section of the switch_character function. For whatever reason, the game's been changed so you can't write to "active" anymore. I'm pretty sure the entire section from line 1601 to line 1623 can be removed now, since switching is now blocked when you're using a Jetpack anyway.