### PR TITLE
New and expanded functions

### DIFF
--- a/boblibrary/recipe-functions.lua
+++ b/boblibrary/recipe-functions.lua
@@ -414,16 +414,29 @@ if mods["recycler"] then
       local source_recipe = data.raw.recipe[recipe_name]
       local target_recipe = data.raw.recipe[target_recipe_name]
       if source_recipe then
+
+        --Calculate the number of items produced by the relevant recipe
+        local source_output_amount = 1
+        local source_output_index = 1
+        for i, source_results in pairs(source_recipe.results) do
+          if source_results.name == recipe_name then
+            source_output_index = i
+          end
+        end
+
+        if source_recipe.results and source_recipe.results[1] then
+          if source_recipe.results[source_output_index].amount then
+            source_output_amount = source_recipe.results[source_output_index].amount
+          elseif source_recipe.results[source_output_index].amount_min and source_recipe.results[source_output_index].amount_max then
+            source_output_amount = (data.raw.recipe[item_name].results[source_output_index].amount_min + data.raw.recipe[item_name].results[source_output_index].amount_max) / 2
+          end
+        end
+
         if target_recipe then
           local new_time = source_recipe.energy_required or 0.5
-          target_recipe.energy_required = new_time / 16
+          target_recipe.energy_required = (new_time / source_output_amount) / 16
           target_recipe.results = {}
-          local source_output_amount = 1
-          for i, source_results in pairs(source_recipe.results) do
-            if source_results.name == recipe_name then
-              source_output_amount = source_results.amount
-            end
-          end
+
           for i, outputs in pairs(source_recipe.ingredients) do
             if source_recipe.ingredients[i].type == "item" then
               table.insert(target_recipe.results, {
@@ -484,6 +497,64 @@ if mods["recycler"] then
       for i, single_recipe in pairs(recipe_name) do
         bobmods.lib.recipe.update_recycling_recipe_single(single_recipe, true)
       end
+    end
+  end
+
+  function bobmods.lib.recipe.update_recycling_recipe_to_self_recipe(item_name, recycle_time)
+    --Use bobmods.lib.recipe.update_recycling_recipe_icon to update icon if necessary
+    --Checks if an item of the given name exists as any valid type
+
+    local item_type = bobmods.lib.item.get_type(item_name)
+    if type(item_name) == "string" and item_type and item_type ~= "fluid" then
+      local target_recipe_name = item_name .. "-recycling"
+      local target_recipe = data.raw.recipe[target_recipe_name]
+      --Calculate recycle time based on a default recipe of the same name as the item if one exists, or override with recycle_time input
+      local source_output_amount = 1
+      local source_output_index = 1
+      local source_recipe = data.raw.recipe[item_name]
+      if source_recipe then
+        for i, source_results in pairs(source_recipe.results) do
+          if source_results.name == item_name then
+            source_output_index = i
+          end
+        end
+        if source_recipe.results and source_recipe.results[1] then
+          if source_recipe.results[source_output_index].amount then
+            source_output_amount = source_recipe.results[source_output_index].amount
+          elseif source_recipe.results[source_output_index].amount_min and source_recipe.results[source_output_index].amount_max then
+            source_output_amount = (source_recipe.results[source_output_index].amount_min + source_recipe.results[source_output_index].amount_max) / 2
+          end
+        end
+      end
+
+      if target_recipe then
+        local new_time = 0.5 / 16
+        if recycle_time then
+          new_time = recycle_time
+        elseif source_recipe and source_recipe.energy_required then
+          new_time = (source_recipe.energy_required / source_output_amount) / 16
+        end
+
+        target_recipe.results = {
+          {
+            type = "item",
+            name = item_name,
+            amount = 1,
+            ignored_by_stats = 1,
+            independent_probability = 0.25,
+          }
+        }
+        
+      else
+        log(debug.traceback())
+        bobmods.lib.error.recipe(recipe_name)
+      end
+    elseif item_type == "fluid" then
+      log(debug.traceback())
+      log(item_name .. " is a fluid.")
+    else
+      log(debug.traceback())
+      bobmods.lib.error.item(item_name)
     end
   end
 

--- a/boblibrary/technology-functions.lua
+++ b/boblibrary/technology-functions.lua
@@ -2,6 +2,51 @@ if not bobmods.lib.tech then
   bobmods.lib.tech = {}
 end
 
+local simple_list = {
+  ["character-logistic-requests"] = true,
+  ["unlock-circuit-network"] = true,
+  ["cliff-deconstruction-enabled"] = true,
+  ["create-ghost-on-entity-death"] = true,
+  ["mining-with-fluid"] = true,
+  ["rail-planner-allow-elevated-rails"] = true,
+  ["rail-support-on-deep-oil-ocean"] = true,
+  ["unlock-space-platforms"] = true,
+  ["unlock-travel-to-space-platforms"] = true,
+  ["unlock-logistic-network"] = true,
+  ["vehicle-logistics"] = true,
+  ["artillery-range"] = true,
+  ["beacon-distribution"] = true,
+  ["belt-stack-size-bonus"] = true,
+  ["bulk-inserter-capacity-bonus"] = true,
+  ["cargo-landing-pad-count"] = true,
+  ["character-build-distance"] = true,
+  ["character-crafting-speed"] = true,
+  ["character-health-bonus"] = true,
+  ["character-inventory-slots-bonus"] = true,
+  ["character-item-drop-distance"] = true,
+  ["character-item-pickup-distance"] = true,
+  ["character-logistic-trash-slots"] = true,
+  ["character-loot-pickup-distance"] = true,
+  ["character-mining-speed"] = true,
+  ["character-reach-distance"] = true,
+  ["character-resource-reach-distance"] = true,
+  ["character-running-speed"] = true,
+  ["deconstruction-time-to-live"] = true,
+  ["follower-robot-lifetime"] = true,
+  ["inserter-stack-size-bonus"] = true,
+  ["laboratory-productivity"] = true,
+  ["laboratory-speed"] = true,
+  ["max-cargo-bay-unloading-distance"] = true,
+  ["max-failed-attempts-per-tick-per-construction-queue"] = true,
+  ["max-successful-attempts-per-tick-per-construction-queue"] = true,
+  ["maximum-following-robots-count"] = true,
+  ["mining-drill-productivity-bonus"] = true,
+  ["train-braking-force-bonus"] = true,
+  ["worker-robot-battery"] = true,
+  ["worker-robot-speed"] = true,
+  ["worker-robot-storage"] = true,
+}
+
 local function add_new_science_pack(technology, pack, amount)
   if technology.unit and technology.unit.ingredients then
     local addit = true
@@ -175,6 +220,84 @@ function bobmods.lib.tech.set_science_pack_count(technology, count)
   end
 end
 
+local function check_tech_modifier_validity(modifier)
+  local valid_modifier = false
+  --Check if modifier argument has the necessary parameters in the table.
+  if (modifier.type == "unlock-recipe" or modifier.type == "change-recipe-productivity") and modifier.recipe then
+    valid_modifier = true
+  elseif modifier.type == "turret-attack" and modifier.turret_id then
+    valid_modifier = true
+  elseif (modifier.type == "ammo-damage" or modifier.type == "gun-speed") and modifier.ammo_category then
+    valid_modifier = true
+  elseif modifier.type == "give-item" and modifier.item then
+    valid_modifier = true
+  elseif modifier.type == "nothing" and modifier.effect_description then
+    valid_modifier = true
+  elseif modifier.type == "unlock-space-location" and modifier.space_location then
+    valid_modifier = true
+  elseif modifier.type == "unlock-quality" and modifier.quality then
+    valid_modifier = true
+  elseif simple_list[modifier.type] and modifier.modifier then
+    valid_modifier = true
+  else
+    log(debug.traceback())
+    log("Given modifier table is not a valid tech effect.")
+  end
+
+  return valid_modifier
+end
+
+local function find_matching_tech_modifier(effects, modifier)
+  --Tries to find a match in the given effects table for the given modifier. Returns index, or 0 for no match.
+  local match_found = 0
+  for i, effect in pairs(effects) do
+    if (effect.type == "unlock-recipe" or effect.type == "change-recipe-productivity") and modifier.recipe and effect.recipe == modifier.recipe then
+      match_found = i
+    elseif effect.type == "turret-attack" and modifier.turret_id and effect.turret_id == modifier.turret_id then
+      match_found = i
+    elseif (effect.type == "ammo-damage" or effect.type == "gun-speed") and modifier.ammo_category and effect.ammo_category == modifier.ammo_category then
+      match_found = i
+    elseif effect.type == "give-item" and modifier.item and effect.item == modifier.item then
+      match_found = i
+    elseif effect.type == "nothing" and modifier.effect_description and serpent.line(effect.effect_description) == serpent.line(modifier.effect_description) then
+      match_found = i
+    elseif effect.type == "unlock-space-location" and modifier.space_location and effect.space_location == modifier.space_location then
+      match_found = i
+    elseif effect.type == "unlock-quality" and modifier.quality and effect.quality == modifier.quality then
+      match_found = i
+    elseif simple_list[modifier.type] and effect.type == modifier.type then
+      match_found = i
+    end
+  end
+
+  return match_found
+end
+
+local function find_modifier_insert_index(effects, insert_string)
+  local insert_target
+  for i, effect in pairs(effects) do
+    if (effect.type == "unlock-recipe" or effect.type == "change-recipe-productivity") and effect.recipe == insert_string then
+      insert_target = i
+    elseif effect.type == "turret-attack" and effect.turret_id == insert_string then
+      insert_target = i
+    elseif (effect.type == "ammo-damage" or effect.type == "gun-speed") and effect.ammo_category == insert_string then
+      insert_target = i
+    elseif effect.type == "give-item" and effect.item == insert_string then
+      insert_target = i
+    elseif effect.type == "nothing" and serpent.line(effect.effect_description) == serpent.line(insert_string) then
+      insert_target = i
+    elseif effect.type == "unlock-space-location" and effect.space_location == insert_string then
+      insert_target = i
+    elseif effect.type == "unlock-quality" and effect.quality == insert_string then
+      insert_target = i
+    elseif effect.type == insert_string then
+      insert_target = i
+    end
+  end
+
+  return insert_target
+end
+
 local function has_recipe_unlock(technology, recipe)
   if technology.effects then
     for i, effect in pairs(technology.effects) do
@@ -186,18 +309,35 @@ local function has_recipe_unlock(technology, recipe)
   return false
 end
 
-local function add_recipe_unlock(technology, recipe)
+local function add_recipe_unlock(technology, recipe, insert_at, insert_before)
+
   local addit = true
   if not technology.effects then
     technology.effects = {}
   end
+
   for i, effect in pairs(technology.effects) do
     if effect.type == "unlock-recipe" and effect.recipe == recipe then
       addit = false
     end
   end
   if addit then
-    table.insert(technology.effects, { type = "unlock-recipe", recipe = recipe })
+    --insert_at allows inputs of both numbers (for indexes) and strings (for placing after specific subtables). For simple or boolean modifiers, match insert_at to the modifier type. Otherwise, match it to the secondary key parameter - usually a category to be modified or a name. In some instances, the same string may match multiple subtables, in which case the new entry will go after the last match. If insert_at is a string or table, "insert_before" can be used to insert the new entry before the target instead of after.
+    local insert_target = #technology.effects + 1
+    if type(insert_at) == "number" then
+      insert_target = insert_at
+    elseif type(insert_at) == "string" or type(insert_at) == "table" then
+      local string_target = find_modifier_insert_index(technology.effects, insert_at)
+      if string_target then
+        if insert_before == true then
+          insert_target = string_target
+        else
+          insert_target = string_target + 1
+        end
+      end
+    end
+
+    table.insert(technology.effects, insert_target, { type = "unlock-recipe", recipe = recipe })
   end
 end
 
@@ -230,14 +370,14 @@ function bobmods.lib.tech.has_recipe_unlock(technology, recipe)
   end
 end
 
-function bobmods.lib.tech.add_recipe_unlock(technology, recipe)
+function bobmods.lib.tech.add_recipe_unlock(technology, recipe, insert_at, insert_before)
   if
     type(technology) == "string"
     and type(recipe) == "string"
     and data.raw.technology[technology]
     and data.raw.recipe[recipe]
   then
-    add_recipe_unlock(data.raw.technology[technology], recipe)
+    add_recipe_unlock(data.raw.technology[technology], recipe, insert_at, insert_before)
   else
     log(debug.traceback())
     bobmods.lib.error.technology(technology)
@@ -257,6 +397,188 @@ function bobmods.lib.tech.remove_recipe_unlock(technology, recipe)
     log(debug.traceback())
     bobmods.lib.error.technology(technology)
     bobmods.lib.error.recipe(recipe)
+  end
+end
+
+function bobmods.lib.tech.add_tech_modifier(technology, modifier, insert_at, insert_before)
+
+  --Insert any modifier into a technology's effects. Use a full table for the modifier argument.
+  if
+    type(technology) == "string"
+    and type(modifier) == "table"
+    and data.raw.technology[technology]
+  then
+
+    local valid_modifier = check_tech_modifier_validity(modifier)
+
+    if valid_modifier == true then
+      local target_technology = data.raw.technology[technology]
+      if not target_technology.effects then
+        target_technology.effects = {}
+      end
+
+      if find_matching_tech_modifier(target_technology.effects, modifier) == 0 then
+
+        --insert_at allows inputs of both numbers (for indexes) and strings (for placing after specific subtables). For simple or boolean modifiers, match insert_at to the modifier type. Otherwise, match it to the secondary key parameter - usually a category to be modified or a name. In some instances, the same string may match multiple subtables, in which case the new entry will go after the last match. If insert_at is a string or table, "insert_before" can be used to insert the new entry before the target instead of after.
+        local insert_target = #target_technology.effects + 1
+        if type(insert_at) == "number" then
+          insert_target = insert_at
+        elseif type(insert_at) == "string" or type(insert_at) == "table" then
+          local string_target = find_modifier_insert_index(target_technology.effects, insert_at)
+          if string_target then
+            if insert_before == true then
+              insert_target = string_target
+            else
+              insert_target = string_target + 1
+            end
+          end
+        end
+
+        table.insert(target_technology.effects, insert_target, modifier)
+
+      end
+    end
+  elseif type(modifier) ~= "table" then
+    log(debug.traceback())
+    log("Modifier is not a table.")
+  else
+    log(debug.traceback())
+    bobmods.lib.error.technology(technology)
+  end
+end
+
+function bobmods.lib.tech.set_tech_modifier(technology, modifier_ID, new_value)
+
+  --Set an existing technology effect to a new value. For modifier_ID argument, give a table that contains the key identifying parameter or parameters. i.e. {ammo_category = "bullet"}, or {turret_id = "gun-turret"}, or for simple modifiers (those that only use "type" and "modifier" parameters), {type = "train-braking-force-bonus"}. new_value must also be a table, and in a few select cases, multiple parameters may be modified at once.
+  if
+    type(technology) == "string"
+    and type(modifier_ID) == "table"
+    and type(new_value) == "table"
+    and data.raw.technology[technology]
+  then
+
+    local target_technology = data.raw.technology[technology]
+    if not target_technology.effects then
+      target_technology.effects = {}
+    end
+
+    local matched_index = find_matching_tech_modifier(target_technology.effects, modifier_ID)
+    if matched_index ~= 0 then
+
+      local target_effect = target_technology.effects[matched_index]
+      if target_effect.type == "unlock-recipe" then
+        if new_value.recipe then
+          target_technology.effects[matched_index].recipe = new_value.recipe
+        else
+          log(debug.traceback())
+          log("Given new_value is not applicable to matched effect.")
+        end
+      elseif target_effect.type == "change-recipe-productivity" then
+        if new_value.change then
+          target_technology.effects[matched_index].recipe = new_value.change
+        else
+          log(debug.traceback())
+          log("Given new_value is not applicable to matched effect.")
+        end
+      elseif target_effect.type == "give-item" then
+        if new_value.item then
+          target_technology.effects[matched_index].item = new_value.item
+        end
+        if new_value.count then
+          target_technology.effects[matched_index].count = new_value.count
+        end
+        if new_value.quality then
+          target_technology.effects[matched_index].quality = new_value.quality
+        end
+      elseif target_effect.type == "nothing" then
+        if new_value.effect_description then
+          target_technology.effects[matched_index].effect_description = new_value.effect_description
+        else
+          log(debug.traceback())
+          log("Given new_value is not applicable to matched effect.")
+        end
+      elseif target_effect.type == "unlock-space-location" then
+        if new_value.space_location then
+          target_technology.effects[matched_index].space_location = new_value.space_location
+        else
+          log(debug.traceback())
+          log("Given new_value is not applicable to matched effect.")
+        end
+      elseif target_effect.type == "unlock-quality" then
+        if new_value.quality then
+          target_technology.effects[matched_index].quality = new_value.quality
+        else
+          log(debug.traceback())
+          log("Given new_value is not applicable to matched effect.")
+        end
+      elseif
+        simple_list[target_effect.type]
+        or target_effect.type == "ammo-damage"
+        or target_effect.type == "gun-speed"
+        or target_effect.type == "turret-attack"
+      then
+        if new_value.modifier then
+          target_technology.effects[matched_index].modifier = new_value.modifier
+        else
+          log(debug.traceback())
+          log("Given new_value is not applicable to matched effect.")
+        end
+      end
+    end
+
+  elseif type(modifier_ID) ~= "table" then
+    log(debug.traceback())
+    log("Modifier_ID is not a table.")
+  elseif type(new_value) ~= "table" then
+    log(debug.traceback())
+    log("new_value is not a table.")
+  else
+    log(debug.traceback())
+    bobmods.lib.error.technology(technology)
+  end
+end
+
+function bobmods.lib.tech.remove_tech_modifier(technology, modifier)
+
+  --Remove any modifier into a technology's effects. Use a table for the modifier argument. This function will remove the first effect that matches all parameters given. The table is allowed to be incomplete, so if the "modifier" (or equivalent) parameter of the effect is changed, omitting it will let this function still work.
+  if
+    type(technology) == "string"
+    and type(modifier) == "table"
+    and data.raw.technology[technology]
+  then
+
+    local target_technology = data.raw.technology[technology]
+    if not target_technology.effects then
+      target_technology.effects = {}
+    end
+
+    local remove_index
+    for i, effect in pairs(target_technology.effects) do
+      local is_match = false
+      for v, param in pairs(modifier) do
+        --See if effect has all parameters given in "modifier", and all have the same value. If any do not match, end this loop
+        if effect[v] == param then
+          is_match = true
+        else
+          is_match = false
+          break
+        end
+      end
+      if is_match == true then
+        remove_index = i
+      end
+    end
+
+    if type(remove_index) == "number" then
+      table.remove(target_technology.effects, remove_index)
+    end
+
+  elseif type(modifier) ~= "table" then
+    log(debug.traceback())
+    log("Modifier is not a table.")
+  else
+    log(debug.traceback())
+    bobmods.lib.error.technology(technology)
   end
 end
 

--- a/boblogistics/prototypes/technology-updates.lua
+++ b/boblogistics/prototypes/technology-updates.lua
@@ -1,4 +1,4 @@
-bobmods.lib.tech.add_recipe_unlock("fluid-handling", "bob-storage-tank-all-corners")
+bobmods.lib.tech.add_recipe_unlock("fluid-handling", "bob-storage-tank-all-corners", "storage-tank")
 bobmods.lib.tech.add_recipe_unlock("fluid-handling", "bob-valve")
 bobmods.lib.tech.add_recipe_unlock("fluid-handling", "bob-overflow-valve")
 bobmods.lib.tech.add_recipe_unlock("fluid-handling", "bob-topup-valve")
@@ -232,7 +232,7 @@ end
 
 if settings.startup["bobmods-logistics-beltoverhaul"].value == true then
   bobmods.lib.tech.add_prerequisite("logistics", "logistics-0")
-  bobmods.lib.tech.add_recipe_unlock("logistics", "transport-belt")
+  bobmods.lib.tech.add_recipe_unlock("logistics", "transport-belt", 1)
   bobmods.lib.tech.add_prerequisite("logistic-science-pack", "logistics")
 end
 
@@ -300,24 +300,24 @@ bobmods.lib.tech.remove_recipe_unlock("logistic-robotics", "roboport")
 
 if settings.startup["bobmods-logistics-robotparts"].value == true then
   bobmods.lib.tech.add_recipe_unlock("robotics", "bob-robot-brain")
-  bobmods.lib.tech.add_recipe_unlock("construction-robotics", "bob-robot-tool-construction")
-  bobmods.lib.tech.add_recipe_unlock("logistic-robotics", "bob-robot-tool-logistic")
+  bobmods.lib.tech.add_recipe_unlock("construction-robotics", "bob-robot-tool-construction", "construction-robot", true)
+  bobmods.lib.tech.add_recipe_unlock("logistic-robotics", "bob-robot-tool-logistic", "logistic-robot", true)
 
-  bobmods.lib.tech.add_recipe_unlock("bob-robots-1", "bob-robot-brain-2")
-  bobmods.lib.tech.add_recipe_unlock("bob-robots-1", "bob-robot-tool-construction-2")
-  bobmods.lib.tech.add_recipe_unlock("bob-robots-1", "bob-robot-tool-logistic-2")
+  bobmods.lib.tech.add_recipe_unlock("bob-robots-1", "bob-robot-tool-construction-2", 1)
+  bobmods.lib.tech.add_recipe_unlock("bob-robots-1", "bob-robot-tool-logistic-2", 1)
+  bobmods.lib.tech.add_recipe_unlock("bob-robots-1", "bob-robot-brain-2", 1)
 
-  bobmods.lib.tech.add_recipe_unlock("bob-robots-2", "bob-robot-brain-3")
-  bobmods.lib.tech.add_recipe_unlock("bob-robots-2", "bob-robot-tool-construction-3")
-  bobmods.lib.tech.add_recipe_unlock("bob-robots-2", "bob-robot-tool-logistic-3")
+  bobmods.lib.tech.add_recipe_unlock("bob-robots-2", "bob-robot-tool-construction-3", 1)
+  bobmods.lib.tech.add_recipe_unlock("bob-robots-2", "bob-robot-tool-logistic-3", 1)
+  bobmods.lib.tech.add_recipe_unlock("bob-robots-2", "bob-robot-brain-3", 1)
 
-  bobmods.lib.tech.add_recipe_unlock("bob-robots-3", "bob-robot-brain-4")
-  bobmods.lib.tech.add_recipe_unlock("bob-robots-3", "bob-robot-tool-construction-4")
-  bobmods.lib.tech.add_recipe_unlock("bob-robots-3", "bob-robot-tool-logistic-4")
+  bobmods.lib.tech.add_recipe_unlock("bob-robots-3", "bob-robot-tool-construction-4", 1)
+  bobmods.lib.tech.add_recipe_unlock("bob-robots-3", "bob-robot-tool-logistic-4", 1)
+  bobmods.lib.tech.add_recipe_unlock("bob-robots-3", "bob-robot-brain-4", 1)
 end
 
-bobmods.lib.tech.add_recipe_unlock("steam-power", "bob-copper-pipe")
-bobmods.lib.tech.add_recipe_unlock("steam-power", "bob-copper-pipe-to-ground")
+bobmods.lib.tech.add_recipe_unlock("steam-power", "bob-copper-pipe", "pipe-to-ground")
+bobmods.lib.tech.add_recipe_unlock("steam-power", "bob-copper-pipe-to-ground", "bob-copper-pipe")
 
 bobmods.lib.tech.add_recipe_unlock("steel-processing", "bob-steel-pipe")
 bobmods.lib.tech.add_recipe_unlock("steel-processing", "bob-steel-pipe-to-ground")

--- a/bobplates/prototypes/technology-updates.lua
+++ b/bobplates/prototypes/technology-updates.lua
@@ -40,8 +40,8 @@ bobmods.lib.tech.add_recipe_unlock("oil-processing", "bob-resin-oil")
 bobmods.lib.tech.add_recipe_unlock("oil-processing", "bob-liquid-fuel")
 bobmods.lib.tech.add_recipe_unlock("advanced-oil-processing", "bob-enriched-fuel")
 
-bobmods.lib.tech.add_recipe_unlock("advanced-oil-processing", "bob-petroleum-gas-cracking")
-bobmods.lib.tech.add_recipe_unlock("advanced-oil-processing", "bob-coal-cracking")
+bobmods.lib.tech.add_recipe_unlock("advanced-oil-processing", "bob-petroleum-gas-cracking", "light-oil-cracking")
+bobmods.lib.tech.add_recipe_unlock("advanced-oil-processing", "bob-coal-cracking", "heavy-oil-cracking", true)
 
 bobmods.lib.tech.add_recipe_unlock("plastics", "bob-synthetic-wood")
 
@@ -96,8 +96,8 @@ bobmods.lib.tech.add_recipe_unlock("bob-cobalt-processing", "bob-cobalt-steel-be
 bobmods.lib.tech.add_recipe_unlock("bob-cobalt-processing", "bob-cobalt-steel-bearing")
 
 if not mods["space-age"] then
-  bobmods.lib.tech.add_recipe_unlock("bob-lithium-processing", "lithium-plate")
   bobmods.lib.tech.add_recipe_unlock("bob-lithium-processing", "bob-lithium-chloride")
+  bobmods.lib.tech.add_recipe_unlock("bob-lithium-processing", "lithium-plate")
   bobmods.lib.tech.add_recipe_unlock("bob-lithium-processing", "bob-lithium-perchlorate")
 else
   data.raw.technology["bob-battery-2"].prerequisites = {}
@@ -125,7 +125,7 @@ else
   bobmods.lib.tech.add_recipe_unlock("bob-battery-3", "bob-lithium-cobalt-oxide")
   bobmods.lib.tech.add_recipe_unlock("bob-battery-3", "bob-battery-3")
   bobmods.lib.tech.hide("bob-lithium-processing")
-  bobmods.lib.tech.add_recipe_unlock("lithium-processing", "bob-lithium-chloride")
+  bobmods.lib.tech.add_recipe_unlock("lithium-processing", "bob-lithium-chloride", 1)
   bobmods.lib.tech.add_recipe_unlock("lithium-processing", "bob-lithium-perchlorate")
 end
 

--- a/bobrevamp/data-updates.lua
+++ b/bobrevamp/data-updates.lua
@@ -76,8 +76,8 @@ if settings.startup["bobmods-revamp-oil"].value == true then
     bobmods.lib.tech.remove_recipe_unlock("oil-processing", "sulfur")
     bobmods.lib.recipe.hide("sulfur")
   end
-  bobmods.lib.tech.add_recipe_unlock("flammables", "bob-solid-fuel-from-sour-gas")
-  bobmods.lib.tech.add_recipe_unlock("oil-processing", "bob-petroleum-gas-sweetening")
+  bobmods.lib.tech.add_recipe_unlock("flammables", "bob-solid-fuel-from-sour-gas", 1)
+  bobmods.lib.tech.add_recipe_unlock("oil-processing", "bob-petroleum-gas-sweetening", "bob-oil-processing")
   bobmods.lib.create_gas_bottle(data.raw.fluid["bob-sour-gas"])
 
   if data.raw.fluid["bob-hydrogen-sulfide"] then

--- a/bobrevamp/prototypes/hard-mode-updates.lua
+++ b/bobrevamp/prototypes/hard-mode-updates.lua
@@ -16,14 +16,14 @@ if bobmods.plates and settings.startup["bobmods-revamp-hardmode"].value == true 
 
   bobmods.lib.recipe.set_ingredient("bob-petroleum-gas-cracking", { type = "fluid", name = "water", amount = 20 })
 
-  bobmods.lib.tech.add_recipe_unlock("bob-chemical-processing-2", "bob-limestone")
+  bobmods.lib.tech.add_recipe_unlock("bob-chemical-processing-2", "bob-limestone", 1)
 
   if not mods["space-age"] then
-    bobmods.lib.tech.add_recipe_unlock("bob-lithium-processing", "bob-sodium-chlorate")
-    bobmods.lib.tech.add_recipe_unlock("bob-lithium-processing", "bob-sodium-perchlorate")
+    bobmods.lib.tech.add_recipe_unlock("bob-lithium-processing", "bob-sodium-chlorate", "bob-lithium-perchlorate", true)
+    bobmods.lib.tech.add_recipe_unlock("bob-lithium-processing", "bob-sodium-perchlorate", "bob-lithium-perchlorate", true)
   else
-    bobmods.lib.tech.add_recipe_unlock("lithium-processing", "bob-sodium-chlorate")
-    bobmods.lib.tech.add_recipe_unlock("lithium-processing", "bob-sodium-perchlorate")
+    bobmods.lib.tech.add_recipe_unlock("lithium-processing", "bob-sodium-chlorate", "bob-lithium-perchlorate", true)
+    bobmods.lib.tech.add_recipe_unlock("lithium-processing", "bob-sodium-perchlorate", "bob-lithium-perchlorate", true)
   end
   if data.raw.fluid["bob-pure-water"] then
     bobmods.lib.recipe.replace_ingredient("bob-sodium-chlorate", "water", "bob-pure-water")
@@ -39,12 +39,12 @@ if bobmods.plates and settings.startup["bobmods-revamp-hardmode"].value == true 
   )
 
   bobmods.lib.tech.add_recipe_unlock("bob-chemical-processing-2", "bob-carbon-dioxide")
-  bobmods.lib.tech.add_recipe_unlock("advanced-oil-processing", "bob-carbon-dioxide-oil-processing")
+  bobmods.lib.tech.add_recipe_unlock("advanced-oil-processing", "bob-carbon-dioxide-oil-processing", "advanced-oil-processing")
   bobmods.lib.tech.add_prerequisite("advanced-oil-processing", "bob-chemical-processing-2")
 
   bobmods.lib.recipe.replace_ingredient("bob-sulfuric-acid-2", "water", "bob-hydrogen-peroxide")
   bobmods.lib.recipe.replace_ingredient("bob-nitric-acid", "water", "bob-hydrogen-peroxide")
-  bobmods.lib.tech.add_recipe_unlock("sulfur-processing", "bob-hydrogen-peroxide")
-  bobmods.lib.tech.add_recipe_unlock("bob-nitrogen-processing", "bob-hydrogen-peroxide")
+  bobmods.lib.tech.add_recipe_unlock("sulfur-processing", "bob-hydrogen-peroxide", 1)
+  bobmods.lib.tech.add_recipe_unlock("bob-nitrogen-processing", "bob-hydrogen-peroxide", 1)
   bobmods.lib.tech.remove_recipe_unlock("bob-hydrazine", "bob-hydrogen-peroxide")
 end

--- a/bobwarfare/prototypes/technology/technology-updates.lua
+++ b/bobwarfare/prototypes/technology/technology-updates.lua
@@ -233,271 +233,97 @@ bobmods.lib.tech.add_prerequisite("uranium-ammo", "bob-bullets")
 bobmods.lib.tech.add_prerequisite("uranium-ammo", "bob-shotgun-shells")
 bobmods.lib.tech.add_recipe_unlock("uranium-ammo", "bob-shotgun-uranium-shell")
 
-table.insert(
-  data.raw.technology["physical-projectile-damage-1"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-2", modifier = 0.1 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-1"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-3", modifier = 0.1 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-1"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-4", modifier = 0.1 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-1"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-5", modifier = 0.1 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-1"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-1", modifier = 0.1 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-1"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-2", modifier = 0.1 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-1"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-3", modifier = 0.1 }
-)
+bobmods.lib.tech.remove_tech_modifier("physical-projectile-damage-1", { type = "turret-attack", turret_id = "gun-turret" })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-1", { type = "turret-attack", turret_id = "gun-turret", modifier = 0.1 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-1", { type = "turret-attack", turret_id = "bob-gun-turret-2", modifier = 0.1 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-1", { type = "turret-attack", turret_id = "bob-gun-turret-3", modifier = 0.1 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-1", { type = "turret-attack", turret_id = "bob-gun-turret-4", modifier = 0.1 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-1", { type = "turret-attack", turret_id = "bob-gun-turret-5", modifier = 0.1 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-1", { type = "turret-attack", turret_id = "bob-sniper-turret-1", modifier = 0.1 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-1", { type = "turret-attack", turret_id = "bob-sniper-turret-2", modifier = 0.1 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-1", { type = "turret-attack", turret_id = "bob-sniper-turret-3", modifier = 0.1 })
 
-table.insert(
-  data.raw.technology["physical-projectile-damage-2"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-2", modifier = 0.1 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-2"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-3", modifier = 0.1 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-2"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-4", modifier = 0.1 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-2"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-5", modifier = 0.1 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-2"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-1", modifier = 0.1 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-2"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-2", modifier = 0.1 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-2"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-3", modifier = 0.1 }
-)
+bobmods.lib.tech.remove_tech_modifier("physical-projectile-damage-2", { type = "turret-attack", turret_id = "gun-turret" })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-2", { type = "turret-attack", turret_id = "gun-turret", modifier = 0.1 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-2", { type = "turret-attack", turret_id = "bob-gun-turret-2", modifier = 0.1 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-2", { type = "turret-attack", turret_id = "bob-gun-turret-3", modifier = 0.1 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-2", { type = "turret-attack", turret_id = "bob-gun-turret-4", modifier = 0.1 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-2", { type = "turret-attack", turret_id = "bob-gun-turret-5", modifier = 0.1 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-2", { type = "turret-attack", turret_id = "bob-sniper-turret-1", modifier = 0.1 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-2", { type = "turret-attack", turret_id = "bob-sniper-turret-2", modifier = 0.1 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-2", { type = "turret-attack", turret_id = "bob-sniper-turret-3", modifier = 0.1 })
 
-table.insert(
-  data.raw.technology["physical-projectile-damage-3"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-2", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-3"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-3", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-3"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-4", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-3"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-5", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-3"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-1", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-3"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-2", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-3"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-3", modifier = 0.2 }
-)
+bobmods.lib.tech.remove_tech_modifier("physical-projectile-damage-3", { type = "turret-attack", turret_id = "gun-turret" })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-3", { type = "turret-attack", turret_id = "gun-turret", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-3", { type = "turret-attack", turret_id = "bob-gun-turret-2", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-3", { type = "turret-attack", turret_id = "bob-gun-turret-3", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-3", { type = "turret-attack", turret_id = "bob-gun-turret-4", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-3", { type = "turret-attack", turret_id = "bob-gun-turret-5", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-3", { type = "turret-attack", turret_id = "bob-sniper-turret-1", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-3", { type = "turret-attack", turret_id = "bob-sniper-turret-2", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-3", { type = "turret-attack", turret_id = "bob-sniper-turret-3", modifier = 0.2 })
 
-table.insert(
-  data.raw.technology["physical-projectile-damage-4"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-2", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-4"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-3", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-4"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-4", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-4"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-5", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-4"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-1", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-4"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-2", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-4"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-3", modifier = 0.2 }
-)
+bobmods.lib.tech.remove_tech_modifier("physical-projectile-damage-4", { type = "turret-attack", turret_id = "gun-turret" })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-4", { type = "turret-attack", turret_id = "gun-turret", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-4", { type = "turret-attack", turret_id = "bob-gun-turret-2", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-4", { type = "turret-attack", turret_id = "bob-gun-turret-3", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-4", { type = "turret-attack", turret_id = "bob-gun-turret-4", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-4", { type = "turret-attack", turret_id = "bob-gun-turret-5", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-4", { type = "turret-attack", turret_id = "bob-sniper-turret-1", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-4", { type = "turret-attack", turret_id = "bob-sniper-turret-2", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-4", { type = "turret-attack", turret_id = "bob-sniper-turret-3", modifier = 0.2 })
 
-table.insert(
-  data.raw.technology["physical-projectile-damage-5"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-2", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-5"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-3", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-5"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-4", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-5"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-5", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-5"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-1", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-5"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-2", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-5"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-3", modifier = 0.2 }
-)
+bobmods.lib.tech.remove_tech_modifier("physical-projectile-damage-5", { type = "turret-attack", turret_id = "gun-turret" })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-5", { type = "turret-attack", turret_id = "gun-turret", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-5", { type = "turret-attack", turret_id = "bob-gun-turret-2", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-5", { type = "turret-attack", turret_id = "bob-gun-turret-3", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-5", { type = "turret-attack", turret_id = "bob-gun-turret-4", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-5", { type = "turret-attack", turret_id = "bob-gun-turret-5", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-5", { type = "turret-attack", turret_id = "bob-sniper-turret-1", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-5", { type = "turret-attack", turret_id = "bob-sniper-turret-2", modifier = 0.2 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-5", { type = "turret-attack", turret_id = "bob-sniper-turret-3", modifier = 0.2 })
 
-table.insert(
-  data.raw.technology["physical-projectile-damage-6"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-2", modifier = 0.4 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-6"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-3", modifier = 0.4 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-6"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-4", modifier = 0.4 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-6"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-5", modifier = 0.4 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-6"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-1", modifier = 0.4 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-6"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-2", modifier = 0.4 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-6"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-3", modifier = 0.4 }
-)
+bobmods.lib.tech.remove_tech_modifier("physical-projectile-damage-6", { type = "turret-attack", turret_id = "gun-turret" })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-6", { type = "turret-attack", turret_id = "gun-turret", modifier = 0.4 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-6", { type = "turret-attack", turret_id = "bob-gun-turret-2", modifier = 0.4 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-6", { type = "turret-attack", turret_id = "bob-gun-turret-3", modifier = 0.4 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-6", { type = "turret-attack", turret_id = "bob-gun-turret-4", modifier = 0.4 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-6", { type = "turret-attack", turret_id = "bob-gun-turret-5", modifier = 0.4 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-6", { type = "turret-attack", turret_id = "bob-sniper-turret-1", modifier = 0.4 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-6", { type = "turret-attack", turret_id = "bob-sniper-turret-2", modifier = 0.4 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-6", { type = "turret-attack", turret_id = "bob-sniper-turret-3", modifier = 0.4 })
 
-table.insert(
-  data.raw.technology["physical-projectile-damage-7"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-2", modifier = 0.7 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-7"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-3", modifier = 0.7 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-7"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-4", modifier = 0.7 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-7"].effects,
-  { type = "turret-attack", turret_id = "bob-gun-turret-5", modifier = 0.7 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-7"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-1", modifier = 0.7 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-7"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-2", modifier = 0.7 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-7"].effects,
-  { type = "turret-attack", turret_id = "bob-sniper-turret-3", modifier = 0.7 }
-)
+bobmods.lib.tech.remove_tech_modifier("physical-projectile-damage-7", { type = "turret-attack", turret_id = "gun-turret" })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-7", { type = "turret-attack", turret_id = "gun-turret", modifier = 0.7 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-7", { type = "turret-attack", turret_id = "bob-gun-turret-2", modifier = 0.7 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-7", { type = "turret-attack", turret_id = "bob-gun-turret-3", modifier = 0.7 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-7", { type = "turret-attack", turret_id = "bob-gun-turret-4", modifier = 0.7 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-7", { type = "turret-attack", turret_id = "bob-gun-turret-5", modifier = 0.7 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-7", { type = "turret-attack", turret_id = "bob-sniper-turret-1", modifier = 0.7 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-7", { type = "turret-attack", turret_id = "bob-sniper-turret-2", modifier = 0.7 })
+bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-7", { type = "turret-attack", turret_id = "bob-sniper-turret-3", modifier = 0.7 })
 
-table.insert(
-  data.raw.technology["physical-projectile-damage-5"].effects,
-  { type = "ammo-damage", ammo_category = "artillery-shell", modifier = 0.9 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-6"].effects,
-  { type = "ammo-damage", ammo_category = "artillery-shell", modifier = 1.3 }
-)
-table.insert(
-  data.raw.technology["physical-projectile-damage-7"].effects,
-  { type = "ammo-damage", ammo_category = "artillery-shell", modifier = 1 }
-)
+if not mods["space-age"] then
+  bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-5", { type = "ammo-damage", ammo_category = "artillery-shell", modifier = 0.9 }, "cannon-shell")
+  bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-6", { type = "ammo-damage", ammo_category = "artillery-shell", modifier = 1.3 }, "cannon-shell")
+  bobmods.lib.tech.add_tech_modifier("physical-projectile-damage-7", { type = "ammo-damage", ammo_category = "artillery-shell", modifier = 1 }, "cannon-shell")
+else
+  bobmods.lib.tech.set_tech_modifier("artillery-shell-damage-1", { ammo_category = "artillery-shell" }, { modifier = 0.5 })
+end
 
-table.insert(
-  data.raw.technology["laser-weapons-damage-1"].effects,
-  { type = "ammo-damage", ammo_category = "bob-laser-rifle", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["laser-weapons-damage-2"].effects,
-  { type = "ammo-damage", ammo_category = "bob-laser-rifle", modifier = 0.2 }
-)
-table.insert(
-  data.raw.technology["laser-weapons-damage-3"].effects,
-  { type = "ammo-damage", ammo_category = "bob-laser-rifle", modifier = 0.3 }
-)
-table.insert(
-  data.raw.technology["laser-weapons-damage-4"].effects,
-  { type = "ammo-damage", ammo_category = "bob-laser-rifle", modifier = 0.4 }
-)
-table.insert(
-  data.raw.technology["laser-weapons-damage-5"].effects,
-  { type = "ammo-damage", ammo_category = "bob-laser-rifle", modifier = 0.5 }
-)
-table.insert(
-  data.raw.technology["laser-weapons-damage-6"].effects,
-  { type = "ammo-damage", ammo_category = "bob-laser-rifle", modifier = 0.7 }
-)
-table.insert(
-  data.raw.technology["laser-weapons-damage-7"].effects,
-  { type = "ammo-damage", ammo_category = "bob-laser-rifle", modifier = 0.7 }
-)
+bobmods.lib.tech.add_tech_modifier("laser-weapons-damage-1", { type = "ammo-damage", ammo_category = "bob-laser-rifle", modifier = 0.2 }, "laser")
+bobmods.lib.tech.add_tech_modifier("laser-weapons-damage-2", { type = "ammo-damage", ammo_category = "bob-laser-rifle", modifier = 0.2 }, "laser")
+bobmods.lib.tech.add_tech_modifier("laser-weapons-damage-3", { type = "ammo-damage", ammo_category = "bob-laser-rifle", modifier = 0.3 }, "laser")
+bobmods.lib.tech.add_tech_modifier("laser-weapons-damage-4", { type = "ammo-damage", ammo_category = "bob-laser-rifle", modifier = 0.4 }, "laser")
+bobmods.lib.tech.add_tech_modifier("laser-weapons-damage-5", { type = "ammo-damage", ammo_category = "bob-laser-rifle", modifier = 0.5 }, "laser")
+bobmods.lib.tech.add_tech_modifier("laser-weapons-damage-6", { type = "ammo-damage", ammo_category = "bob-laser-rifle", modifier = 0.7 }, "laser")
+bobmods.lib.tech.add_tech_modifier("laser-weapons-damage-7", { type = "ammo-damage", ammo_category = "bob-laser-rifle", modifier = 0.7 }, "laser")
 
-table.insert(
-  data.raw.technology["laser-shooting-speed-3"].effects,
-  { type = "gun-speed", ammo_category = "bob-laser-rifle", modifier = 0.3 }
-)
-table.insert(
-  data.raw.technology["laser-shooting-speed-4"].effects,
-  { type = "gun-speed", ammo_category = "bob-laser-rifle", modifier = 0.4 }
-)
-table.insert(
-  data.raw.technology["laser-shooting-speed-5"].effects,
-  { type = "gun-speed", ammo_category = "bob-laser-rifle", modifier = 0.4 }
-)
-table.insert(
-  data.raw.technology["laser-shooting-speed-6"].effects,
-  { type = "gun-speed", ammo_category = "bob-laser-rifle", modifier = 0.5 }
-)
-table.insert(
-  data.raw.technology["laser-shooting-speed-7"].effects,
-  { type = "gun-speed", ammo_category = "bob-laser-rifle", modifier = 0.5 }
-)
+bobmods.lib.tech.add_tech_modifier("laser-shooting-speed-3", { type = "gun-speed", ammo_category = "bob-laser-rifle", modifier = 0.3 })
+bobmods.lib.tech.add_tech_modifier("laser-shooting-speed-4", { type = "gun-speed", ammo_category = "bob-laser-rifle", modifier = 0.4 })
+bobmods.lib.tech.add_tech_modifier("laser-shooting-speed-5", { type = "gun-speed", ammo_category = "bob-laser-rifle", modifier = 0.4 })
+bobmods.lib.tech.add_tech_modifier("laser-shooting-speed-6", { type = "gun-speed", ammo_category = "bob-laser-rifle", modifier = 0.5 })
+bobmods.lib.tech.add_tech_modifier("laser-shooting-speed-7", { type = "gun-speed", ammo_category = "bob-laser-rifle", modifier = 0.5 })
 
 bobmods.lib.tech.remove_science_pack("laser-weapons-damage-1", "chemical-science-pack")
 bobmods.lib.tech.remove_science_pack("laser-weapons-damage-2", "chemical-science-pack")


### PR DESCRIPTION
As brought up in #526, this PR adds new functions that add, remove, or set any technology modifier, as well as adding functionality to add_recipe_unlock to control where the new addition is added - at a specific index, or before or after a specific existing subtable. add_tech_modifier also has this functionality.

These can be used to organize the way technologies are presented to be more clean and organized. I went through a few example files and applied the new functionality to them.

<img width="528" height="505" alt="Screenshot 2026-09-09 210404" src="https://github.com/user-attachments/assets/a667edc6-d818-4486-94a6-d229c52446fa" />

This also gives us the tools to easily maintain consistency even when Space Age randomly decides to change the value of some of these bonuses. For example, the turret attack damage bonus is only 0.2 in Space Age on Physical Attack Damage levels 6 and 7, instead of the vanilla values of 0.4 and 0.7.


In addition, I finally created the function for changing a recycling recipe to a self-recycling one. I also fixed an oversight in the existing recycling update functions so that the number of outputs in the base recipe will be taken into account when determining how long the item should take to recycle, instead of that only counting toward the quantity/probability of outputs.